### PR TITLE
chore: track ghostty and cmux configs via chezmoi

### DIFF
--- a/home/private_dot_config/cmux/private_cmux.json
+++ b/home/private_dot_config/cmux/private_cmux.json
@@ -1,0 +1,366 @@
+{
+  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",
+  "schemaVersion": 1,
+
+  // This file uses JSON with comments (JSONC).
+  // Uncomment and edit any setting to make it file-managed.
+  // Remove a setting to fall back to the value saved in Settings.
+  // cmux creates this template on launch when ~/.config/cmux/cmux.json is missing.
+  // Legacy settings.json files are read only as fallback for keys not present here.
+  //
+  // ---------------------------------------------------------------------------
+  // ACTIVE (file-managed) — curated for an agent-heavy Claude Code / cmux-team
+  // workflow. Everything below the "REFERENCE" divider is the full commented
+  // template (falls back to Settings). Reload with `cmux reload-config`.
+  // ---------------------------------------------------------------------------
+
+  "app": {
+    "appearance": "system",
+    "workspaceInheritWorkingDirectory": true,
+    "reorderOnNotification": true,        // surface the agent that just pinged
+    "warnBeforeClosingTab": true,
+    "openMarkdownInCmuxViewer": true,
+    "confirmQuit": "always"
+  },
+
+  "terminal": {
+    "autoResumeAgentSessions": true,      // resume agents after reopen — key for CC workflows
+    "copyOnSelect": true,                 // mirror the Ghostty copy-on-select choice
+    "showScrollBar": true,
+    "rendererRealization": { "enabled": true, "idleSeconds": 30, "maxWarmRenderers": 12 }
+    // agentHibernation left OFF (default). Enable only if many idle agents strain resources:
+    // "agentHibernation": { "enabled": true, "maxLiveTerminals": 12, "idleSeconds": 5 }
+  },
+
+  "sidebar": {
+    "watchGitStatus": true,
+    "showBranchDirectory": true,
+    "showPullRequests": true,
+    "makePullRequestsClickable": true,
+    "showPorts": true,
+    "openPortLinksInCmuxBrowser": true,
+    "showProgress": true,
+    "branchLayout": "vertical"
+  },
+
+  "automation": {
+    "claudeCodeIntegration": true,        // native detection of Claude Code in cmux terminals
+    "suppressSubagentNotifications": true, // quieter multi-agent runs
+    "socketControlMode": "allowAll"       // TEMP: enabled for out-of-cmux orchestrator control; revert after use
+  },
+
+  "notifications": {
+    "paneFlash": true,
+    "unreadPaneRing": true,
+    "dockBadge": true,
+    "sound": "default",
+    "hooksMode": "append"
+  },
+
+  "browser": {
+    "openTerminalLinksInCmuxBrowser": true,
+    "interceptTerminalOpenCommandInCmuxBrowser": true,
+    "defaultSearchEngine": "google"
+  },
+
+  // ===========================================================================
+  // REFERENCE — full launch template, left commented (falls back to Settings).
+  // The six namespaces above show only the keys we set; the blocks below list
+  // every available key. Uncomment/move a key up into an ACTIVE block to manage
+  // it from this file.
+  // ===========================================================================
+
+  //   "app" : {
+  //     "newWorkspacePlacement" : "afterCurrent",
+  //     "minimalMode" : false,
+  //     "reorderOnNotification" : true,
+  //     "appearance" : "system",
+  //     "openSupportedFilesInCmux" : true,
+  //     "warnBeforeClosingTab" : true,
+  //     "hideTabCloseButton" : false,
+  //     "forkConversationDefaultDestination" : "right",
+  //     "focusPaneOnFirstClick" : false,
+  //     "iMessageMode" : false,
+  //     "preferredEditor" : "",
+  //     "commandPaletteSearchesAllSurfaces" : false,
+  //     "workspaceInheritWorkingDirectory" : true,
+  //     "openMarkdownInCmuxViewer" : true,
+  //     "sendAnonymousTelemetry" : true,
+  //     "keepWorkspaceOpenWhenClosingLastSurface" : false,
+  //     "appIcon" : "automatic",
+  //     "confirmQuit" : "always",
+  //     "renameSelectsExistingName" : true,
+  //     "language" : "system",
+  //     "windowTitleTemplate" : "",
+  //     "menuBarOnly" : false,
+  //     "warnBeforeClosingTabXButton" : false
+  //   },
+
+  //   "workspaceGroups" : {
+  //     "newWorkspacePlacement" : "afterCurrent"
+  //   },
+
+  //   "terminal" : {
+  //     "showTextBoxOnNewTerminals" : false,
+  //     "agentHibernation" : {
+  //       "enabled" : false,
+  //       "maxLiveTerminals" : 12,
+  //       "idleSeconds" : 5
+  //     },
+  //     "textBoxMaxLines" : 10,
+  //     "copyOnSelect" : false,
+  //     "autoResumeAgentSessions" : true,
+  //     "showScrollBar" : true,
+  //     "scrollSpeed" : 1,
+  //     "focusTextBoxOnNewTerminals" : false,
+  //     "resumeCommands" : [
+  //
+  //     ],
+  //     "rendererRealization" : {
+  //       "enabled" : true,
+  //       "idleSeconds" : 30,
+  //       "maxWarmRenderers" : 12
+  //     }
+  //   },
+
+  //   "notifications" : {
+  //     "unreadPaneRing" : true,
+  //     "sound" : "default",
+  //     "customSoundFilePath" : "",
+  //     "hooksMode" : "append",
+  //     "command" : "",
+  //     "dockBadge" : true,
+  //     "hooks" : [
+  //
+  //     ],
+  //     "showInMenuBar" : true,
+  //     "paneFlash" : true
+  //   },
+
+  //   "sidebar" : {
+  //     "wrapWorkspaceTitles" : false,
+  //     "openPortLinksInCmuxBrowser" : true,
+  //     "watchGitStatus" : true,
+  //     "showPorts" : true,
+  //     "showLog" : true,
+  //     "showPullRequests" : true,
+  //     "openPullRequestLinksInCmuxBrowser" : true,
+  //     "showBranchDirectory" : true,
+  //     "showCustomMetadata" : true,
+  //     "showNotificationMessage" : true,
+  //     "hideAllDetails" : false,
+  //     "showWorkspaceDescription" : true,
+  //     "showSSH" : true,
+  //     "showProgress" : true,
+  //     "branchLayout" : "vertical",
+  //     "stackBranchDirectory" : false,
+  //     "pathLastSegmentOnly" : false,
+  //     "makePullRequestsClickable" : true
+  //   },
+
+  //   "workspaceColors" : {
+  //     "indicatorStyle" : "leftRail",
+  //     "selectionColor" : null,
+  //     "notificationBadgeColor" : null,
+  //     "colors" : {
+  //       "Green" : "#196F3D",
+  //       "Purple" : "#6A1B9A",
+  //       "Charcoal" : "#3E4B5E",
+  //       "Olive" : "#4A5C18",
+  //       "Blue" : "#1565C0",
+  //       "Indigo" : "#283593",
+  //       "Navy" : "#1A5276",
+  //       "Crimson" : "#922B21",
+  //       "Aqua" : "#0E6B8C",
+  //       "Brown" : "#7B3F00",
+  //       "Red" : "#C0392B",
+  //       "Teal" : "#006B6B",
+  //       "Rose" : "#880E4F",
+  //       "Amber" : "#7D6608",
+  //       "Orange" : "#A04000",
+  //       "Magenta" : "#AD1457"
+  //     }
+  //   },
+
+  //   "sidebarAppearance" : {
+  //     "darkModeTintColor" : null,
+  //     "matchTerminalBackground" : false,
+  //     "lightModeTintColor" : null,
+  //     "tintOpacity" : 0.17999999999999999,
+  //     "tintColor" : "#000000"
+  //   },
+
+  //   "automation" : {
+  //     "suppressSubagentNotifications" : true,
+  //     "ripgrepBinaryPath" : "",
+  //     "portRange" : 10,
+  //     "kiroNotificationLevel" : "standard",
+  //     "socketPassword" : "",
+  //     "ampIntegration" : true,
+  //     "socketControlMode" : "cmuxOnly",
+  //     "claudeBinaryPath" : "",
+  //     "kiroIntegration" : true,
+  //     "portBase" : 9100,
+  //     "claudeCodeIntegration" : true,
+  //     "cursorIntegration" : true,
+  //     "geminiIntegration" : true
+  //   },
+
+  //   "browser" : {
+  //     "hiddenWebViewDiscardDelaySeconds" : 300,
+  //     "customSearchEngineURLTemplate" : "https:\/\/www.google.com\/search?q={query}",
+  //     "showSearchSuggestions" : true,
+  //     "urlsToAlwaysOpenExternally" : [
+  //
+  //     ],
+  //     "reactGrabVersion" : "0.1.29",
+  //     "showImportHintOnBlankTabs" : true,
+  //     "interceptTerminalOpenCommandInCmuxBrowser" : true,
+  //     "hostsToOpenInEmbeddedBrowser" : [
+  //
+  //     ],
+  //     "theme" : "system",
+  //     "defaultSearchEngine" : "google",
+  //     "customSearchEngineName" : "",
+  //     "discardHiddenWebViews" : true,
+  //     "openTerminalLinksInCmuxBrowser" : true,
+  //     "insecureHttpHostsAllowedInEmbeddedBrowser" : [
+  //       "localhost",
+  //       "*.localhost",
+  //       "127.0.0.1",
+  //       "::1",
+  //       "0.0.0.0",
+  //       "*.localtest.me"
+  //     ]
+  //   },
+
+  //   "markdown" : {
+  //     "fontFamily" : "",
+  //     "maxWidth" : 980,
+  //     "fontSize" : 15
+  //   },
+
+  //   "fileEditor" : {
+  //     "wordWrap" : false
+  //   },
+
+  //   "fileExplorer" : {
+  //     "doubleClickAction" : "preview"
+  //   },
+
+  //   "diffViewer" : {
+  //     "defaultLayout" : "unified"
+  //   },
+
+  //   "shortcuts" : {
+  //     "bindings" : {
+  //       "openSettings" : "cmd+,",
+  //       "diffViewerScrollToTop" : [
+  //         "g",
+  //         "g"
+  //       ],
+  //       "commandPalettePrevious" : "ctrl+p",
+  //       "reloadConfiguration" : "cmd+shift+,",
+  //       "commandPalette" : "cmd+shift+p",
+  //       "focusTextBoxInput" : "cmd+shift+a",
+  //       "browserBack" : "cmd+[",
+  //       "toggleBrowserDeveloperTools" : "cmd+opt+i",
+  //       "fileExplorerOpenSelectionFinderAlias" : "cmd+↓",
+  //       "findNext" : "cmd+g",
+  //       "browserHardReload" : "cmd+shift+r",
+  //       "markdownZoomOut" : "cmd+-",
+  //       "showHideAllWindows" : "cmd+opt+ctrl+.",
+  //       "equalizeSplits" : "cmd+ctrl+=",
+  //       "browserZoomReset" : "cmd+0",
+  //       "toggleBrowserFocusMode" : "cmd+opt+return",
+  //       "clearScreenKeepScrollback" : "cmd+shift+k",
+  //       "focusHistoryBack" : "cmd+[",
+  //       "findInDirectory" : "cmd+shift+f",
+  //       "diffViewerScrollUp" : "k",
+  //       "globalSearch" : "cmd+opt+f",
+  //       "closeWindow" : "cmd+ctrl+w",
+  //       "selectSurfaceByNumber" : "ctrl+1",
+  //       "canvasAlignTop" : "",
+  //       "toggleTerminalCopyMode" : "cmd+shift+m",
+  //       "closeOtherTabsInPane" : "cmd+opt+t",
+  //       "nextSurface" : "cmd+shift+]",
+  //       "openFolder" : "cmd+o",
+  //       "commandPaletteNext" : "ctrl+n",
+  //       "canvasZoomIn" : "cmd+opt+=",
+  //       "splitBrowserRight" : "cmd+opt+d",
+  //       "markOldestUnreadAndJumpNext" : "cmd+ctrl+u",
+  //       "focusDown" : "cmd+opt+↓",
+  //       "focusUp" : "cmd+opt+↑",
+  //       "saveFilePreview" : "cmd+s",
+  //       "sendFeedback" : "",
+  //       "newTab" : "cmd+n",
+  //       "canvasAlignBottom" : "",
+  //       "canvasEqualizeWidths" : "",
+  //       "hideFind" : "cmd+shift+opt+f",
+  //       "fileExplorerOpenSelection" : "return",
+  //       "focusLeft" : "cmd+opt+←",
+  //       "canvasZoomOut" : "cmd+opt+-",
+  //       "splitDown" : "cmd+shift+d",
+  //       "canvasEqualizeHeights" : "",
+  //       "openDiffViewer" : "cmd+shift+ctrl+d",
+  //       "reopenPreviousSession" : "cmd+shift+o",
+  //       "sendCtrlFToTerminal" : "",
+  //       "prevSurface" : "cmd+shift+[",
+  //       "toggleSplitZoom" : "cmd+shift+return",
+  //       "nextSidebarTab" : "cmd+ctrl+]",
+  //       "canvasDistributeVertically" : "",
+  //       "canvasRevealFocusedPane" : "cmd+ctrl+r",
+  //       "toggleSidebar" : "cmd+b",
+  //       "groupSelectedWorkspaces" : "cmd+shift+g",
+  //       "triggerFlash" : "cmd+shift+h",
+  //       "diffViewerScrollToBottom" : "shift+g",
+  //       "markdownZoomReset" : "cmd+0",
+  //       "browserZoomIn" : "cmd+=",
+  //       "canvasDistributeHorizontally" : "",
+  //       "canvasAlignRight" : "",
+  //       "focusRightSidebar" : "cmd+shift+e",
+  //       "browserZoomOut" : "cmd+-",
+  //       "diffViewerScrollDown" : "j",
+  //       "toggleFocusedWorkspaceGroupCollapsed" : "cmd+ctrl+.",
+  //       "useSelectionForFind" : "cmd+e",
+  //       "diffViewerOpenFileSearch" : "\/",
+  //       "reopenClosedBrowserPanel" : "cmd+shift+t",
+  //       "splitRight" : "cmd+d",
+  //       "renameTab" : "cmd+r",
+  //       "canvasZoomReset" : "cmd+opt+0",
+  //       "toggleUnread" : "cmd+opt+u",
+  //       "browserForward" : "cmd+]",
+  //       "newSurface" : "cmd+t",
+  //       "toggleReactGrab" : "cmd+shift+g",
+  //       "canvasTidy" : "cmd+ctrl+t",
+  //       "newWindow" : "cmd+shift+n",
+  //       "focusHistoryForward" : "cmd+]",
+  //       "newBrowserWorkspace" : "cmd+opt+n",
+  //       "openBrowser" : "cmd+shift+l",
+  //       "closeTab" : "cmd+w",
+  //       "showNotifications" : "cmd+i",
+  //       "prevSidebarTab" : "cmd+ctrl+[",
+  //       "toggleFileExplorer" : "cmd+opt+b",
+  //       "canvasAlignLeft" : "",
+  //       "quit" : "cmd+q",
+  //       "toggleCanvasLayout" : "cmd+ctrl+c",
+  //       "findPrevious" : "cmd+opt+g",
+  //       "focusBrowserAddressBar" : "cmd+l",
+  //       "markdownZoomIn" : "cmd+=",
+  //       "attachTextBoxFile" : "cmd+shift+opt+a",
+  //       "editWorkspaceDescription" : "cmd+opt+e",
+  //       "goToWorkspace" : "cmd+p",
+  //       "canvasOverview" : "cmd+ctrl+o",
+  //       "showBrowserJavaScriptConsole" : "cmd+opt+c",
+  //       "renameWorkspace" : "cmd+shift+r",
+  //       "toggleFullScreen" : "cmd+ctrl+f",
+  //       "closeWorkspace" : "cmd+shift+w",
+  //       "jumpToUnread" : "cmd+shift+u",
+  //       "splitBrowserDown" : "cmd+shift+opt+d",
+  //       "selectWorkspaceByNumber" : "cmd+1",
+  //       "focusRight" : "cmd+opt+→",
+  //       "browserReload" : "cmd+r",
+  //       "find" : "cmd+f"
+  //     }
+  //   },
+}

--- a/home/private_dot_config/ghostty/config
+++ b/home/private_dot_config/ghostty/config
@@ -1,0 +1,84 @@
+# ~/.config/ghostty/config
+# Some taken from https://github.com/manaflow-ai/cmux/issues/1657
+# Read directly by cmux (libghostty). Reload in cmux with Cmd+Shift+, .
+
+# --- Font (JetBrainsMono Nerd Font is installed; glyphs power sidebar/prompt icons) ---
+font-family = "JetBrainsMono Nerd Font"
+font-size = 13
+font-thicken = true
+font-thicken-strength = 64
+font-feature = calt
+font-feature = liga
+
+# --- Theme: auto light/dark (catppuccin) ---
+theme = dark:catppuccin-mocha,light:catppuccin-latte
+window-theme = auto
+
+# --- Cursor & selection (catppuccin mocha rosewater accent) ---
+cursor-color = f5e0dc
+cursor-text = 1e1e2e
+cursor-style-blink = false
+cursor-opacity = 0.9
+selection-background = 585b70
+selection-foreground = cdd6f4
+
+# --- cmux-optimized window & splits (issue #1657) ---
+window-show-tab-bar = never          # cmux provides its own tab UI; hide Ghostty's
+unfocused-split-opacity = 0.65       # dim inactive agent panes to clarify focus
+window-padding-x = 12                # breathing room next to the cmux sidebar
+window-padding-y = 10
+window-padding-balance = true
+background-opacity = 0.65            # lower = more transparent. cmux alpha-stacks its own
+                                     # background, so it reads slightly more opaque than
+                                     # standalone Ghostty — drop toward 0.7 for more see-through,
+                                     # raise to 1.0 to disable translucency entirely.
+background-blur = 20                 # macOS frosted-glass behind the transparency (radius in px;
+                                     # `true` also works). Makes low opacity look far better.
+window-padding-color = extend
+window-colorspace = display-p3
+
+# --- Terminal behavior ---
+working-directory = /Users/bossjones/dev
+window-inherit-working-directory = true
+copy-on-select = clipboard
+clipboard-trim-trailing-spaces = false
+clipboard-read = allow
+clipboard-write = allow
+clipboard-paste-protection = true
+clipboard-paste-bracketed-safe = true
+mouse-hide-while-typing = true
+cursor-click-to-move = true
+scroll-to-bottom = keystroke,no-output
+confirm-close-surface = false        # cmux has its own close guards
+scrollback-limit = 10000000
+cursor-style = block
+
+# --- Shell integration ---
+shell-integration = zsh
+shell-integration-features = no-cursor
+term = xterm-256color
+
+# --- macOS ---
+macos-option-as-alt = left           # Option word-nav; 'left' avoids non-US keyboard breakage
+macos-auto-secure-input = true
+macos-titlebar-style = transparent
+focus-follows-mouse = false           # matches cmux's no-focus-stealing policy
+
+# --- Keybindings: split resize + zoom (non-conflicting with cmux.json shortcuts) ---
+keybind = cmd+ctrl+left=resize_split:left,20
+keybind = cmd+ctrl+right=resize_split:right,20
+keybind = cmd+ctrl+up=resize_split:up,10
+keybind = cmd+ctrl+down=resize_split:down,10
+keybind = cmd+shift+z=toggle_split_zoom
+resize-overlay = after-first
+resize-overlay-position = bottom-right
+resize-overlay-duration = 500ms
+
+# --- Keybindings: line editing & misc (no collisions in cmux.json) ---
+keybind = cmd+left=text:\x01
+keybind = cmd+right=text:\x05
+keybind = alt+backspace=text:\x17
+keybind = cmd+k=clear_screen
+keybind = cmd+equal=increase_font_size:2
+keybind = cmd+minus=decrease_font_size:2
+keybind = cmd+0=reset_font_size

--- a/home/shell/config.zsh
+++ b/home/shell/config.zsh
@@ -36,6 +36,12 @@ setopt HIST_FIND_NO_DUPS
 # Don't write duplicate entries in the history file.
 setopt HIST_SAVE_NO_DUPS
 
+# Pattern of commands to exclude from history. The real pattern lives in
+# ~/.secret (untracked, sourced by home/shell/secrets/env.zsh before this
+# file runs) so it never gets committed; fall back to a harmless default
+# when that file/var isn't present on a given machine.
+export HISTORY_IGNORE="${HISTORY_IGNORE:-(exit|clear)}"
+
 # Move cursor to end of word if a full completion is inserted.
 setopt ALWAYS_TO_END
 # Case-insensitive globbing (used in pathname expansion)

--- a/home/shell/customs/aliases.zsh
+++ b/home/shell/customs/aliases.zsh
@@ -2781,6 +2781,26 @@ docker-tail-all() {
     docker ps -q | xargs -L 1 -P $(docker ps | wc -l) docker logs --tail 0 -f
 }
 
+# Toggle XDG_DATA_DIRS to include Homebrew's share dir, or unset it.
+# Homebrew's prefix differs by arch: /opt/homebrew on Apple Silicon, /usr/local on Intel.
+toggle_xdg_data_dirs() {
+    local brew_share
+    if [ -d /opt/homebrew/share ]; then
+        brew_share="/opt/homebrew/share"
+    else
+        brew_share="/usr/local/share"
+    fi
+    local default_dirs="/usr/local/share:/usr/share"
+
+    if [ -n "${XDG_DATA_DIRS}" ] && [[ ":${XDG_DATA_DIRS}:" == *":${brew_share}:"* ]]; then
+        unset XDG_DATA_DIRS
+        echo "[toggle_xdg_data_dirs] unset XDG_DATA_DIRS"
+    else
+        export XDG_DATA_DIRS="${brew_share}:${XDG_DATA_DIRS:-${default_dirs}}"
+        echo "[toggle_xdg_data_dirs] XDG_DATA_DIRS=${XDG_DATA_DIRS}"
+    fi
+}
+
 # ---------------------------------------------------------
 # chezmoi managed - end.zsh
 # ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `toggle_xdg_data_dirs` alias function to arch-aware toggle Homebrew's share dir on/off `XDG_DATA_DIRS`
- Bring `~/.config/ghostty/config` and `~/.config/cmux/cmux.json` under chezmoi management, following the existing `private_dot_config` convention (`private_` prefix preserves `cmux.json`'s 0600 permission)

## Test plan
- [x] `zsh -n home/shell/customs/aliases.zsh` — syntax check passes
- [x] `chezmoi add` output confirms correct target paths (`home/private_dot_config/ghostty/config`, `home/private_dot_config/cmux/private_cmux.json`)
- [ ] `chezmoi diff` shows no unexpected drift once reviewed