### PR TITLE
fix(pre-commit): validate JSONC files instead of excluding them

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,20 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json]
+        # JSONC files are hand-formatted (comment placement, aligned trailing comments).
+        exclude: &jsonc_files ^(\.devcontainer/devcontainer\.json|home/private_dot_config/cmux/private_cmux\.json)$
+
+  # There is no upstream check-jsonc hook (pre-commit-hooks#695, #1196 are still open),
+  # so JSONC files get this one: comments and trailing commas are allowed, everything
+  # else is still strict JSON. Read-only -- it never rewrites the files.
+  - repo: local
+    hooks:
+      - id: check-jsonc
+        name: check jsonc
+        description: Validate JSON-with-comments files
+        entry: python scripts/check-jsonc.py
+        language: python
+        files: *jsonc_files
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -52,7 +66,8 @@ repos:
       # Simply check whether files parse as valid python.
       - id: check-ast
       - id: check-json
-        exclude: ^\.devcontainer/devcontainer\.json$
+        # These two are JSONC; check-jsonc validates them instead.
+        exclude: *jsonc_files
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ pre-commit:
 	uv run pre-commit run -a
 
 test:
-	py.test --tb=short --no-header --showlocals --reruns 6 test_dotfiles.py test_scripts_backup_dotfiles.py
+	py.test --tb=short --no-header --showlocals --reruns 6 test_dotfiles.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
 
 test-pdb:
-	py.test --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_scripts_backup_dotfiles.py
+	py.test --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
 
 uv-test:
-	uv run pytest -vvvv --tb=short --no-header --showlocals --reruns 6 --durations-min=0.05 --durations=10 test_dotfiles.py test_scripts_backup_dotfiles.py
+	uv run pytest -vvvv --tb=short --no-header --showlocals --reruns 6 --durations-min=0.05 --durations=10 test_dotfiles.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
 
 uv-test-pdb:
-	uv run pytest --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_scripts_backup_dotfiles.py
+	uv run pytest --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
 
 .PHONY: update-cursor-rules
 update-cursor-rules:  ## Update cursor rules from prompts/drafts/cursor_rules

--- a/scripts/check-jsonc.py
+++ b/scripts/check-jsonc.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = []
+# ///
+"""
+Validate JSON-with-comments (JSONC) files.
+
+The stock `check-json` pre-commit hook uses Python's strict json module, which rejects
+comments -- so JSONC files like .devcontainer/devcontainer.json and cmux's config had to
+be excluded from it, leaving them with no syntax checking at all. This is the checker
+for those files: comments (and trailing commas) are allowed, everything else is still
+strict JSON.
+
+The file on disk is only ever read. Comments are ignored for the duration of a parse by
+building a comment-free copy of the *text in memory*; the file keeps every comment it
+has. Comment spans are blanked rather than deleted so that reported line/column numbers
+still point at the right place in the original file.
+
+Usage (pre-commit passes the filenames):
+
+    uv run scripts/check-jsonc.py .devcontainer/devcontainer.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class JsoncError(ValueError):
+    """A JSONC file that cannot be parsed even once comments are ignored."""
+
+
+def uncomment(text: str) -> str:
+    """Blank out JSONC comments, leaving a string strict json can parse.
+
+    Scans character by character so that comment markers *inside strings* are treated as
+    data. A regex would truncate `"https://example.com"` at the `//` and then report a
+    bogus syntax error on a perfectly valid file.
+
+    Comments become spaces (newlines preserved) so offsets, and therefore the line and
+    column in any error message, still match the original file.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        char = text[i]
+
+        if char == '"':
+            start = i
+            i += 1
+            while i < n:
+                if text[i] == "\\":  # escape: consume the escaped char too, so \" does
+                    i += 2           # not look like the end of the string
+                    continue
+                if text[i] == '"':
+                    i += 1
+                    break
+                i += 1
+            out.append(text[start:i])
+            continue
+
+        if char == "/" and i + 1 < n:
+            nxt = text[i + 1]
+
+            if nxt == "/":
+                while i < n and text[i] != "\n":
+                    out.append(" ")
+                    i += 1
+                continue
+
+            if nxt == "*":
+                end = text.find("*/", i + 2)
+                if end == -1:
+                    line = text.count("\n", 0, i) + 1
+                    raise JsoncError(f"unterminated block comment starting on line {line}")
+                for ch in text[i : end + 2]:
+                    out.append("\n" if ch == "\n" else " ")
+                i = end + 2
+                continue
+
+        out.append(char)
+        i += 1
+
+    return "".join(out)
+
+
+def drop_trailing_commas(text: str) -> str:
+    """Blank commas that sit just before a closing brace/bracket.
+
+    VS Code's jsonc-parser tolerates trailing commas, so a file that is valid in the
+    editor must not fail this hook. Assumes comments are already gone; still string-aware
+    so a comma inside a string value is left alone.
+    """
+    chars = list(text)
+    i = 0
+    n = len(chars)
+
+    while i < n:
+        char = chars[i]
+
+        if char == '"':
+            i += 1
+            while i < n:
+                if chars[i] == "\\":
+                    i += 2
+                    continue
+                if chars[i] == '"':
+                    break
+                i += 1
+            i += 1
+            continue
+
+        if char == ",":
+            j = i + 1
+            while j < n and chars[j].isspace():
+                j += 1
+            if j < n and chars[j] in "}]":
+                chars[i] = " "
+
+        i += 1
+
+    return "".join(chars)
+
+
+def loads_jsonc(text: str) -> Any:
+    """Parse JSONC text into Python objects. Strict JSON once comments are ignored."""
+    return json.loads(drop_trailing_commas(uncomment(text)))
+
+
+def check_file(path: Path) -> str | None:
+    """Return an error message if `path` is not valid JSONC, else None. Never writes."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return exc.strerror or str(exc)
+
+    try:
+        loads_jsonc(text)
+    except (JsoncError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return str(exc)
+
+    return None
+
+
+def main(argv: list[str]) -> int:
+    failed = False
+
+    for name in argv:
+        error = check_file(Path(name))
+        if error is not None:
+            print(f"{name}: {error}", file=sys.stderr)
+            failed = True
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/test_scripts_check_jsonc.py
+++ b/test_scripts_check_jsonc.py
@@ -1,0 +1,234 @@
+"""
+Tests for ``scripts/check-jsonc.py``.
+
+The script is a standalone PEP 723 ``uv run`` tool with a hyphenated filename, so it
+cannot be imported by name -- it is loaded once via importlib (see the ``mod`` fixture),
+mirroring ``test_scripts_backup_dotfiles.py``.
+
+The checker is read-only: it answers "would this parse as JSON once comments are
+ignored?" without ever writing to the file. Comments are the whole point of the JSONC
+files it guards, so ``test_never_modifies_file`` pins that guarantee down.
+
+Most of the remaining tests defend against *false alarms* rather than missed errors: a
+naive comment scanner sees the ``//`` in ``"https://example.com"`` and blanks the rest
+of the line, which turns a perfectly valid file into a bogus syntax error. The real
+cmux config opens with exactly such a ``$schema`` URL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent
+SCRIPT = REPO_ROOT / "scripts" / "check-jsonc.py"
+
+# The two real JSONC files in the repo that the pre-commit hook is scoped to.
+REAL_JSONC_FILES = [
+    REPO_ROOT / ".devcontainer" / "devcontainer.json",
+    REPO_ROOT / "home" / "private_dot_config" / "cmux" / "private_cmux.json",
+]
+
+
+@pytest.fixture(scope="module")
+def mod() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_jsonc", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_jsonc"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(tmp_path: Path, content: str, name: str = "sample.json") -> Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------------------
+# Accepts: plain JSON and every flavour of JSONC comment
+# --------------------------------------------------------------------------------------
+
+
+def test_plain_json_passes(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{"a": 1}')
+    assert mod.check_file(path) is None
+
+
+def test_full_line_comment_passes(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  // a comment\n  "a": 1\n}')
+    assert mod.check_file(path) is None
+
+
+def test_leading_comment_before_opening_brace_passes(mod: ModuleType, tmp_path: Path) -> None:
+    # This is devcontainer.json's exact shape: a // comment on line 1, before the `{`.
+    path = _write(tmp_path, '// For format details, see https://aka.ms/devcontainer.json.\n{\n  "a": 1\n}')
+    assert mod.check_file(path) is None
+
+
+def test_trailing_comment_after_value_passes(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  "a": 1,  // why a is 1\n  "b": 2\n}')
+    assert mod.check_file(path) is None
+
+
+def test_block_comment_passes(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  /* block */\n  "a": 1\n}')
+    assert mod.check_file(path) is None
+
+
+def test_multiline_block_comment_passes(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  /* line one\n     line two */\n  "a": 1\n}')
+    assert mod.check_file(path) is None
+
+
+def test_trailing_comma_in_object_and_array_passes(mod: ModuleType, tmp_path: Path) -> None:
+    # VS Code's jsonc-parser tolerates these, so a file that is valid in the editor
+    # must not fail the hook.
+    path = _write(tmp_path, '{\n  "a": [1, 2,],\n  "b": 2,\n}')
+    assert mod.check_file(path) is None
+
+
+# --------------------------------------------------------------------------------------
+# False-alarm guards: comment markers that live *inside strings* are data, not comments
+# --------------------------------------------------------------------------------------
+
+
+def test_double_slash_inside_string_is_not_a_comment(mod: ModuleType, tmp_path: Path) -> None:
+    # The real cmux file opens with a $schema URL containing "//".
+    path = _write(
+        tmp_path,
+        '{\n  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux.schema.json",\n'
+        '  "schemaVersion": 1\n}',
+    )
+    assert mod.check_file(path) is None
+
+
+def test_url_value_survives_intact(mod: ModuleType, tmp_path: Path) -> None:
+    # Not just "does it parse" -- the value must not be truncated at the "//".
+    text = '{"url": "https://example.com/a/b"}'
+    assert mod.loads_jsonc(text) == {"url": "https://example.com/a/b"}
+
+
+def test_block_comment_markers_inside_string_are_data(mod: ModuleType, tmp_path: Path) -> None:
+    assert mod.loads_jsonc('{"a": "/* not a comment */"}') == {"a": "/* not a comment */"}
+
+
+def test_escaped_quote_does_not_end_string(mod: ModuleType, tmp_path: Path) -> None:
+    # If the scanner thinks the escaped quote closes the string, it will treat the
+    # following // as a comment and eat the rest of the line, breaking the parse.
+    assert mod.loads_jsonc(r'{"a": "she said \"// hi\"", "b": 2}') == {
+        "a": 'she said "// hi"',
+        "b": 2,
+    }
+
+
+def test_comment_like_text_in_key_is_data(mod: ModuleType, tmp_path: Path) -> None:
+    assert mod.loads_jsonc('{"http://k": 1}') == {"http://k": 1}
+
+
+# --------------------------------------------------------------------------------------
+# Rejects: still strict JSON once comments are ignored
+# --------------------------------------------------------------------------------------
+
+
+def test_missing_brace_fails(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  // fine\n  "a": 1\n')
+    assert mod.check_file(path) is not None
+
+
+def test_unquoted_key_fails(mod: ModuleType, tmp_path: Path) -> None:
+    # JSON5 would accept this; JSONC does not, and neither do we.
+    path = _write(tmp_path, "{\n  a: 1\n}")
+    assert mod.check_file(path) is not None
+
+
+def test_single_quoted_string_fails(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, "{\n  \"a\": 'x'\n}")
+    assert mod.check_file(path) is not None
+
+
+def test_unterminated_block_comment_fails(mod: ModuleType, tmp_path: Path) -> None:
+    path = _write(tmp_path, '{\n  /* never closed\n  "a": 1\n}')
+    assert mod.check_file(path) is not None
+
+
+# --------------------------------------------------------------------------------------
+# CLI contract: mirrors check-json (silent on success, path in the message on failure)
+# --------------------------------------------------------------------------------------
+
+
+def test_main_clean_run_is_silent_and_exits_zero(
+    mod: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    good = _write(tmp_path, '{\n  // ok\n  "a": 1\n}')
+    assert mod.main([str(good)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_reports_only_the_bad_file(
+    mod: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    good = _write(tmp_path, '{"a": 1}', name="good.json")
+    bad = _write(tmp_path, "{oops}", name="bad.json")
+
+    assert mod.main([str(good), str(bad)]) != 0
+
+    err = capsys.readouterr().err
+    assert "bad.json" in err
+    assert "good.json" not in err
+
+
+def test_main_on_missing_file_fails_without_traceback(
+    mod: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "nope.json"
+    assert mod.main([str(missing)]) != 0
+    assert "nope.json" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------------------
+# The guarantee that matters most: the checker never touches the file
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param('{\n  // keep me\n  "a": 1,  // and me\n  "u": "https://x/y"\n}', id="valid-jsonc"),
+        pytest.param('{\n  // keep me\n  "a": oops\n}', id="invalid-jsonc"),
+    ],
+)
+def test_never_modifies_file(mod: ModuleType, tmp_path: Path, content: str) -> None:
+    path = _write(tmp_path, content)
+    before = path.read_bytes()
+
+    mod.main([str(path)])
+
+    assert path.read_bytes() == before
+
+
+# --------------------------------------------------------------------------------------
+# Regression: the two real files the hook is scoped to must actually pass
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", REAL_JSONC_FILES, ids=lambda p: p.name)
+def test_real_repo_jsonc_files_pass(mod: ModuleType, path: Path) -> None:
+    assert path.exists(), f"{path} is in the hook's files: regex but does not exist"
+    assert mod.check_file(path) is None
+
+
+@pytest.mark.parametrize("path", REAL_JSONC_FILES, ids=lambda p: p.name)
+def test_real_repo_jsonc_files_are_genuinely_jsonc(mod: ModuleType, path: Path) -> None:
+    """If one of these ever becomes strict JSON, it belongs back under check-json."""
+    import json
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

`pre-commit run --all-files` fails today on `home/private_dot_config/cmux/private_cmux.json`: `check-json` uses Python's strict `json` module, which rejects the ~300 comments in a file that self-documents `// This file uses JSON with comments (JSONC).`

The repo had already hit this once and papered over it — `check-json` carried `exclude: ^\.devcontainer/devcontainer\.json$` for exactly the same reason. So **both** JSONC files were getting no syntax checking at all, and that blind spot is what let the cmux file land broken. Widening the exclusion would have grown the hole.

This splits the two concerns instead:

- **`check-json`** keeps guarding the 5 genuinely-strict JSON files (`.claude/settings.json`, `.cursor/mcp.json`, `.mcp.json`, `.vscode/settings.json`, `hack/schemas/taskfile.json`), and now excludes both JSONC files rather than just `devcontainer.json`.
- **New `check-jsonc` local hook** validates the 2 JSONC files (`.devcontainer/devcontainer.json`, `home/private_dot_config/cmux/private_cmux.json`): comments and trailing commas allowed, everything else still strict JSON. There is no upstream hook to adopt — [pre-commit-hooks#695](https://github.com/pre-commit/pre-commit-hooks/issues/695) and [#1196](https://github.com/pre-commit/pre-commit-hooks/issues/1196) are both still open — so `scripts/check-jsonc.py` is a stdlib-only PEP 723 `uv run` tool, shaped like the existing `scripts/backup-dotfiles.py`.
- **`prettier`** now excludes the two JSONC files so their hand-authored layout (comment placement, aligned trailing comments) survives.

Neither JSONC file can be renamed to `.jsonc` — the devcontainer spec and cmux both require the `.json` name — so the hooks split by **path**, via a shared YAML anchor.

## The checker never rewrites your files

It is read-only, same contract as `check-json`. The comments stay in the files — they are the whole reason those files need a JSONC checker in the first place. Comments are ignored only in an **in-memory copy** of the text, because `json.loads` cannot be handed a string containing them, and the spans are *blanked rather than deleted* so reported line numbers still point at the right line in the original file. A parametrized test asserts the file is byte-for-byte identical after a run, on both a valid and an invalid file.

## Why the scan is string-aware

This is what most of the tests defend, and the risk is **false alarms**, not comment loss. The cmux file's `"$schema"` value is `https://raw.githubusercontent.com/...` — it contains `//`. A naive comment scanner reads that as the start of a comment, blanks the rest of the line, and then reports a bogus syntax error on a perfectly valid file. Tests cover `//` and `/* */` inside strings, escaped quotes (`"she said \"// hi\""`), and comment-like text in keys.

Stdlib only, no `json5`/`commentjson` dependency: it keeps the hook installable with no `additional_dependencies`, and JSON5 is *too* permissive — it also accepts unquoted keys and single-quoted strings, which would wave through genuinely malformed config. Both are covered by rejection tests.

## Test plan

- [x] 25 new tests in `test_scripts_check_jsonc.py`, written **before** the script (TDD) and confirmed failing first — all 25 errored on the missing module
- [x] Full suite green: **48 passed, 4 skipped** (the 4 skips are pre-existing unconditional `@pytest.mark.skip`s in `test_dotfiles.py`)
- [x] `uv run pre-commit run --all-files` passes — **and no hook modifies any file** (`git status` clean afterward). This is the acceptance criterion; it fails on `main` today.
- [x] Regression tests run the checker against the two **real** repo files, so the hook and the files cannot drift apart, plus an inverse test asserting those files are still genuinely JSONC (if one ever becomes strict JSON it belongs back under `check-json`)
- [x] Negative check: a deliberately broken JSONC file exits non-zero and reports the correct original line number
- [x] Standalone: `uv run scripts/check-jsonc.py .devcontainer/devcontainer.json home/private_dot_config/cmux/private_cmux.json` exits 0, silent
- [x] `Makefile` test targets updated to include the new test file

## Known limitations

- The `mirrors-prettier` rev is pinned to `v4.0.0-alpha.8` — an alpha, ~2 years stale — and it disagrees with current prettier about these files: the pinned hook *rewrites* `private_cmux.json`, while a direct `npx prettier@3 --check` reports both JSONC files as already prettier-clean. Excluding the JSONC files from prettier sidesteps this, but **the stale pin is a latent issue worth its own bump**, out of scope here.
- `check-jsonc` uses `language: python` with `entry: python scripts/check-jsonc.py` rather than `uv run`, so the hook works without `uv` on PATH (Docker smoke test, pre-commit.ci). The script itself is still independently `uv run`-able via its PEP 723 header.
- Trailing commas are accepted (VS Code's jsonc-parser tolerates them, so a file valid in the editor must not fail the hook), though neither current file uses any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCJbutZp3967PEPvnGN62