### PR TITLE
feat(config): manage ccstatusline settings via chezmoi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,13 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml, json]
-        # JSONC files are hand-formatted (comment placement, aligned trailing comments).
-        exclude: &jsonc_files ^(\.devcontainer/devcontainer\.json|home/private_dot_config/cmux/private_cmux\.json)$
+        # Two kinds of file opt out of reformatting:
+        #   - JSONC files are hand-formatted (comment placement, aligned trailing comments).
+        #   - ccstatusline rewrites its settings.json on every TUI save as
+        #     JSON.stringify(settings, null, 2). Reformatting it here (prettier collapses
+        #     single-element arrays onto one line) would make every save show up as
+        #     chezmoi drift for zero semantic change. See test_ccstatusline_settings.py.
+        exclude: ^(\.devcontainer/devcontainer\.json|home/private_dot_config/cmux/private_cmux\.json|home/private_dot_config/ccstatusline/settings\.json)$
 
   # There is no upstream check-jsonc hook (pre-commit-hooks#695, #1196 are still open),
   # so JSONC files get this one: comments and trailing commas are allowed, everything
@@ -58,7 +63,7 @@ repos:
         description: Validate JSON-with-comments files
         entry: python scripts/check-jsonc.py
         language: python
-        files: *jsonc_files
+        files: &jsonc_files ^(\.devcontainer/devcontainer\.json|home/private_dot_config/cmux/private_cmux\.json)$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -72,6 +77,9 @@ repos:
       - id: check-merge-conflict
       - id: check-symlinks
       - id: end-of-file-fixer
+        # JSON.stringify emits no trailing newline; adding one here would be permanent
+        # one-byte chezmoi drift against what ccstatusline writes.
+        exclude: ^home/private_dot_config/ccstatusline/settings\.json$
       - id: mixed-line-ending
       - id: trailing-whitespace
 

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ pre-commit:
 	uv run pre-commit run -a
 
 test:
-	py.test --tb=short --no-header --showlocals --reruns 6 test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
+	py.test --tb=short --no-header --showlocals --reruns 6 test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py test_ccstatusline_settings.py
 
 test-pdb:
-	py.test --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
+	py.test --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py test_ccstatusline_settings.py
 
 uv-test:
-	uv run pytest -vvvv --tb=short --no-header --showlocals --reruns 6 --durations-min=0.05 --durations=10 test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
+	uv run pytest -vvvv --tb=short --no-header --showlocals --reruns 6 --durations-min=0.05 --durations=10 test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py test_ccstatusline_settings.py
 
 uv-test-pdb:
-	uv run pytest --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py
+	uv run pytest --pdb --pdbcls bpdb:BPdb --tb=short --no-header --showlocals test_dotfiles.py test_fzf_tab.py test_scripts_backup_dotfiles.py test_scripts_check_jsonc.py test_ccstatusline_settings.py
 
 .PHONY: update-cursor-rules
 update-cursor-rules:  ## Update cursor rules from prompts/drafts/cursor_rules

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Optional features are prompted at init. **Note:** of the eight boolean prompts, 
 │   ├── .chezmoi.yaml.tmpl    # feature flags + pinned tool versions
 │   ├── .chezmoiscripts/      # run_ provisioning scripts (per-OS, ordered)
 │   ├── .chezmoiexternal.yaml # git externals (oh-my-tmux, boss-cheatsheets)
-│   └── private_dot_config/   # ~/.config payloads (iterm2, sheldon, ghostty, cmux)
+│   └── private_dot_config/   # ~/.config payloads (iterm2, sheldon, ghostty, cmux, ccstatusline)
 ├── docs/                     # ← this documentation set
 ├── scripts/                  # PEP 723 helper scripts (backup-dotfiles, check-jsonc)
 ├── ai_docs/                  # generated notes: reports/, workflows/, cheatsheets/

--- a/home/private_dot_config/ccstatusline/settings.json
+++ b/home/private_dot_config/ccstatusline/settings.json
@@ -1,0 +1,146 @@
+{
+  "version": 3,
+  "lines": [
+    [
+      {
+        "id": "1",
+        "type": "model",
+        "color": "cyan"
+      },
+      {
+        "id": "2",
+        "type": "separator"
+      },
+      {
+        "id": "3",
+        "type": "context-length",
+        "color": "brightBlack"
+      },
+      {
+        "id": "4",
+        "type": "separator"
+      },
+      {
+        "id": "5",
+        "type": "git-branch",
+        "color": "magenta"
+      },
+      {
+        "id": "6",
+        "type": "separator"
+      },
+      {
+        "id": "7",
+        "type": "git-insertions",
+        "color": "green"
+      },
+      {
+        "id": "419e7ac2-9830-47de-b306-41654846e4a7",
+        "type": "separator"
+      },
+      {
+        "id": "7b1f5d3e-4c3a-4e2a-8f0a-9c2d1a6e5b4f",
+        "type": "git-deletions",
+        "color": "red"
+      },
+      {
+        "id": "7c2e6d4f-5d4b-4f3b-9a1b-ad3e2b7f6c5a",
+        "type": "separator"
+      },
+      {
+        "id": "3d8b2240-fdd7-4c14-a1cb-15d6c01c29a4",
+        "type": "tokens-total",
+        "color": "brightBlack"
+      },
+      {
+        "id": "3b897942-15b1-472b-8f02-22cf3f8ec040",
+        "type": "separator"
+      },
+      {
+        "id": "80464136-b933-47a4-bd60-0d1dd37892e5",
+        "type": "session-cost",
+        "color": "green"
+      }
+    ],
+    [
+      {
+        "id": "3a832d94-78b4-427e-83c4-72a22a09cc89",
+        "type": "session-usage",
+        "color": "brightBlue"
+      },
+      {
+        "id": "3e4f9ce7-f4ec-4795-a47e-c3bf92a9cede",
+        "type": "separator"
+      },
+      {
+        "id": "ae67996b-8ac9-4ab6-90df-595987ad1dfe",
+        "type": "session-clock",
+        "color": "brightBlack"
+      },
+      {
+        "id": "12c8e019-a3a2-4a8c-bd47-757812aa0179",
+        "type": "separator"
+      },
+      {
+        "id": "8b131b63-b889-4d71-95c1-71add8c0f1f7",
+        "type": "weekly-usage",
+        "color": "blue"
+      },
+      {
+        "id": "d127c26e-a709-4058-b75f-fb7733710d2e",
+        "type": "separator"
+      },
+      {
+        "id": "8d3f7e5c-6e5c-4a3b-8b2c-be4f3c8a7d6b",
+        "type": "weekly-reset-timer",
+        "color": "brightBlack"
+      }
+    ],
+    [
+      {
+        "id": "7e9e06ac-7e92-48bf-a4ba-83d04d670f75",
+        "type": "context-bar",
+        "color": "yellow"
+      },
+      {
+        "id": "8011cbb9-bc39-46c4-aeff-258052a093f8",
+        "type": "separator"
+      },
+      {
+        "id": "9e4f8d6c-7f6d-4b4c-9c3d-cf5a4d9b8e7c",
+        "type": "sandbox-status",
+        "color": "red"
+      },
+      {
+        "id": "9f5a9e7d-8a7e-4c5d-ad4e-da6b5eac9f8d",
+        "type": "separator"
+      },
+      {
+        "id": "6634ce8a-2a00-4ed2-83ad-bbce3fb2dddd",
+        "type": "current-working-dir",
+        "color": "brightBlue"
+      }
+    ]
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 2,
+  "defaultPaddingSide": "both",
+  "inheritSeparatorColors": false,
+  "globalBold": false,
+  "gitCacheTtlSeconds": 5,
+  "minimalistMode": false,
+  "powerline": {
+    "enabled": false,
+    "separators": [
+      ""
+    ],
+    "separatorInvertBackground": [
+      false
+    ],
+    "startCaps": [],
+    "endCaps": [],
+    "autoAlign": false,
+    "continueThemeAcrossLines": false
+  }
+}

--- a/test_ccstatusline_settings.py
+++ b/test_ccstatusline_settings.py
@@ -1,0 +1,185 @@
+"""
+Tests for the chezmoi-managed ccstatusline config.
+
+``ccstatusline`` (https://github.com/sirmalloc/ccstatusline) reads its config from a
+hardcoded ``~/.config/ccstatusline/settings.json``. We track it in the chezmoi source at
+``home/private_dot_config/ccstatusline/settings.json`` so every machine renders the same
+Claude Code status line.
+
+Two properties are worth pinning down, and neither is obvious from reading the file:
+
+1. **It must stay machine-agnostic.** ccstatusline writes an ``installation`` block (how
+   *this* box installed it -- pinned vs self-managed, npm vs bun, a pinned version) and a
+   transient ``updatemessage`` block into the very same file. Committing either would push
+   one laptop's install method onto every other machine. ``test_no_machine_local_metadata``
+   is the guard.
+
+2. **It must stay a plain file, not a template.** The whole point is that the config is
+   byte-identical everywhere -- there is no OS, hostname, or feature-flag branching -- so a
+   ``.tmpl`` sibling or a stray ``{{`` would be a regression, not an enhancement.
+
+These are source-tree assertions: they read the file in the repo, not the applied copy in
+``$HOME``. Deliberately so -- any TUI tweak on this laptop would otherwise red the suite
+until it was re-committed. ``chezmoi status`` is the right tool for drift.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import typing as t
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent
+
+# chezmoi source path. `.chezmoiroot` is `home`, and `private_dot_config/` -> `~/.config/`
+# (0700), so this renders to the target below. Intermediate dirs stay plain-named, matching
+# the sibling cmux/ ghostty/ iterm2/ payloads.
+SOURCE_FILE = REPO_ROOT / "home" / "private_dot_config" / "ccstatusline" / "settings.json"
+
+# The path ccstatusline itself hardcodes (src/utils/config.ts: DEFAULT_SETTINGS_PATH).
+TARGET_PATH = ".config/ccstatusline/settings.json"
+
+# Keys ccstatusline writes that describe *this* machine, not the desired status line.
+MACHINE_LOCAL_KEYS = (
+    "installation",
+    "updatemessage",
+)
+
+# ccstatusline renders at most three status lines.
+MAX_LINES = 3
+
+CHEZMOI = shutil.which("chezmoi")
+
+
+Settings = dict[str, t.Any]
+Widget = dict[str, t.Any]
+
+
+@pytest.fixture(scope="module")
+def settings() -> Settings:
+    """The committed config, parsed."""
+    data: object = json.loads(SOURCE_FILE.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return t.cast(Settings, data)
+
+
+# --------------------------------------------------------------------------------------
+# The file is present and is strict JSON
+# --------------------------------------------------------------------------------------
+
+
+def test_source_file_exists() -> None:
+    assert SOURCE_FILE.is_file(), f"{SOURCE_FILE} is missing from the chezmoi source"
+
+
+def test_parses_as_strict_json() -> None:
+    """Not JSONC. Mirrors the ``check-json`` pre-commit hook so ``make test`` catches a
+    broken file even when hooks are skipped -- and pins that this file must *not* be added
+    to the ``&jsonc_files`` exclude anchor in .pre-commit-config.yaml."""
+    json.loads(SOURCE_FILE.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------------------
+# Shape: enough to catch a bad hand-merge, not a reimplementation of ccstatusline's schema
+# --------------------------------------------------------------------------------------
+
+
+def test_version_is_an_int(settings: Settings) -> None:
+    assert isinstance(settings["version"], int)
+
+
+def test_lines_shape(settings: Settings) -> None:
+    lines: list[list[Widget]] = settings["lines"]
+    assert isinstance(lines, list)
+    assert 1 <= len(lines) <= MAX_LINES, f"ccstatusline renders at most {MAX_LINES} lines"
+    assert any(line for line in lines), "every status line is empty"
+
+    for index, line in enumerate(lines):
+        assert isinstance(line, list), f"lines[{index}] is not a list"
+        for widget in line:
+            assert isinstance(widget, dict), f"lines[{index}] holds a non-object widget"
+            assert isinstance(widget.get("id"), str), f"lines[{index}] widget missing str id"
+            assert isinstance(widget.get("type"), str), f"lines[{index}] widget missing str type"
+
+
+def test_widget_ids_are_unique(settings: Settings) -> None:
+    """ccstatusline keys widgets by id; duplicates from a hand-merge misbehave silently."""
+    lines: list[list[Widget]] = settings["lines"]
+    ids: list[str] = [widget["id"] for line in lines for widget in line]
+    duplicates = sorted({i for i in ids if ids.count(i) > 1})
+    assert not duplicates, f"duplicate widget ids: {duplicates}"
+
+
+# --------------------------------------------------------------------------------------
+# The guarantee that matters most: this config is shared, so it stays machine-agnostic
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("key", MACHINE_LOCAL_KEYS, ids=lambda k: k)
+def test_no_machine_local_metadata(settings: Settings, key: str) -> None:
+    """``installation`` records how ccstatusline was installed on one specific box and
+    ``updatemessage`` is transient update-nag state. Either one, committed, gets applied to
+    every other machine. Strip them before committing a fresh export."""
+    assert key not in settings, (
+        f"{SOURCE_FILE.name} contains machine-local key {key!r}; "
+        "remove it so the config stays identical across machines"
+    )
+
+
+def test_is_not_a_template() -> None:
+    """No ``.tmpl`` sibling, and no Go-template delimiters in the body."""
+    assert not SOURCE_FILE.with_suffix(".json.tmpl").exists()
+    assert "{{" not in SOURCE_FILE.read_text(encoding="utf-8")
+
+
+def test_matches_ccstatusline_writer_format() -> None:
+    """The committed bytes must be exactly what ccstatusline itself would write.
+
+    Every TUI save rewrites the file as ``JSON.stringify(settings, null, 2)`` -- 2-space
+    indent, no trailing newline -- which Python reproduces exactly as
+    ``json.dumps(..., indent=2, ensure_ascii=False)``. If the committed copy is formatted
+    any other way, ``chezmoi status`` reports drift after every save even when nothing
+    semantically changed, and the real signal gets lost in the noise.
+
+    This is why ``.pre-commit-config.yaml`` excludes this one file from ``prettier``
+    (which collapses single-element arrays onto one line) and from ``end-of-file-fixer``
+    (which would append a trailing newline). Re-including it will fail this test.
+    """
+    raw = SOURCE_FILE.read_text(encoding="utf-8")
+    expected = json.dumps(json.loads(raw), indent=2, ensure_ascii=False)
+    assert raw == expected, (
+        "settings.json is not in ccstatusline's own output format; "
+        "re-export it from the TUI (or reformat) instead of letting a formatter touch it"
+    )
+
+
+# --------------------------------------------------------------------------------------
+# End-to-end: chezmoi resolves the source path to ~/.config/ccstatusline/settings.json
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(CHEZMOI is None, reason="chezmoi is not installed")
+def test_chezmoi_manages_target() -> None:
+    """The source path is only correct if chezmoi maps it to the hardcoded target path.
+
+    Read-only: ``chezmoi managed`` never writes. It does need a rendered chezmoi config for
+    the ``.chezmoi.yaml.tmpl`` prompts, which exists on a provisioned machine and in CI
+    after ``chezmoi init`` -- elsewhere we skip rather than fail.
+    """
+    assert CHEZMOI is not None
+    result = subprocess.run(
+        [CHEZMOI, "managed", "--source", str(REPO_ROOT)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"chezmoi managed failed (unprovisioned machine?): {result.stderr.strip()}")
+
+    assert TARGET_PATH in result.stdout.splitlines(), (
+        f"chezmoi does not map the source file to {TARGET_PATH}"
+    )


### PR DESCRIPTION
## What

Tracks `~/.config/ccstatusline/settings.json` — the config for [ccstatusline](https://github.com/sirmalloc/ccstatusline), the Claude Code status line — in the chezmoi source, so every machine renders the same status line instead of it living only on one laptop.

Follows the existing `private_dot_config/` convention already used for cmux, ghostty, and iTerm2. ccstatusline hardcodes this path (`src/utils/config.ts`: `DEFAULT_SETTINGS_PATH`), so `home/private_dot_config/ccstatusline/settings.json` → `~/.config/ccstatusline/settings.json`.

Scope is deliberately just this file. `~/.claude/settings.json` (where the `statusLine` command block lives) stays unmanaged — it carries per-machine permissions/hooks/auth state.

## Design notes

**Plain `.json`, not a `.tmpl`.** The config is intentionally identical everywhere — no OS, hostname, or feature-flag branching. There are no `*.json.tmpl` files in this repo.

**No `private_` prefix.** The file is `0644` and holds no secrets. `private_` is used here only to preserve a genuinely restricted mode (`private_cmux.json` → 0600).

**Byte-identical to ccstatusline's own writer.** Every TUI save rewrites the file as `JSON.stringify(settings, null, 2)`. Prettier reformats that (it collapses single-element arrays onto one line) and `end-of-file-fixer` appends a trailing newline — so a formatted copy would make *every* save show up as `chezmoi status` drift for zero semantic change, drowning out real signal. This one path is therefore excluded from both hooks, and a test pins the format so nobody silently re-includes it. The `&jsonc_files` YAML anchor moved to the `check-jsonc` hook so prettier's exclude can differ from `check-json`'s (this file is strict JSON and must stay under `check-json`).

## Test

New `test_ccstatusline_settings.py` (10 tests, wired into all four Makefile targets so CI's `make test` picks it up). The two that carry real weight:

- **`test_no_machine_local_metadata`** — ccstatusline writes an `installation` block (pinned vs self-managed, npm vs bun, pinned version) and a transient `updatemessage` block into this same file. Committing either pushes one laptop's install method onto every other machine. This is what actually protects "common config across all machines".
- **`test_matches_ccstatusline_writer_format`** — asserts the committed bytes equal `json.dumps(..., indent=2, ensure_ascii=False)`, which reproduces `JSON.stringify(x, null, 2)` exactly. Verified against real `prettier@3` output: the test rejects it.

Plus: file exists, parses as strict JSON, widget shape, widget-id uniqueness, not a template, and `chezmoi managed` really resolves the source path to `.config/ccstatusline/settings.json` (skips when chezmoi is absent or unprovisioned).

Deliberately **not** asserting the applied `$HOME` copy matches the source — any TUI tweak would then red the suite until re-committed. `chezmoi status` is the right tool for drift.

## Verification

```
$ uv run pytest test_ccstatusline_settings.py     # 10 passed
$ make test (equivalent)                          # 59 passed, 8 skipped (pre-existing)
$ uv run pre-commit run --all-files               # all hooks pass, settings.json untouched
$ chezmoi managed --source .  | grep ccstatusline # .config/ccstatusline/settings.json
$ chezmoi status --source .   | grep ccstatusline # no drift
```

No `chezmoi apply` was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXS8RaQWWAyjMF6KBuWKDG