### PR TITLE
feat(shell): make the CUDA env version-agnostic and existence-guarded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,18 @@ A comprehensive dotfiles management system using **chezmoi** for ZSH configurati
 ```bash
 make test           # Run pytest with retries and tmux-based integration tests
 make test-pdb       # Run tests with debugger (bpdb)
+make smoke-cuda     # Verify home/shell/cuda/* shell modules against real NVIDIA apt packages (no GPU needed)
+make smoke-gpu      # Verify a CUDA toolkit against the host's real driver in a container (GPU required)
 ```
+
+> **`home/shell/cuda/` has no CI coverage.** The GitHub Actions matrix is macOS-only, and the
+> `cuda` sheldon plugin is gated on `.chezmoi.os == "linux"`, so no CI job ever sources
+> `custom.zsh`/`posix-env.sh`. `make smoke-cuda`/`make smoke-gpu` (see
+> [docs/testing-and-ci.md](docs/testing-and-ci.md#cuda--gpu-verification-rigs)) are the only real
+> gate for that code — run them after touching those files. `ZSH_DOTFILES_CUDA_ROOT` overrides the
+> toolkit search prefix, which is the hook for testing the resolution logic against a throwaway
+> directory instead of `/usr/local`. `LD_LIBRARY_PATH` is intentionally never set by these modules —
+> see the comment header in `home/shell/cuda/custom.zsh`.
 
 ### Development Tasks
 ```bash

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1.4
+# CUDA shell-module verification container (no GPU required).
+#
+# Verifies home/shell/cuda/custom.zsh and home/shell/cuda/posix-env.sh against
+# REAL NVIDIA apt packages, real update-alternatives, and real
+# /etc/ld.so.conf.d -- none of which the pytest suite or CI can cover, because
+# CI runs on macOS only and the cuda sheldon plugin is Linux-gated.
+#
+# No GPU and no nvidia-container-toolkit needed: the code under test only
+# inspects the filesystem. For driver/runtime checks that DO need a GPU, use
+# Dockerfile.gpu instead.
+#
+# Deliberately jammy, not the ubuntu:24.04 of Dockerfile: NVIDIA's apt repos are
+# per-distro (ubuntu2204 vs ubuntu2404), and boss-deeplearning is 22.04. Adding a
+# repo that installs a priority-600 apt pin to the standard smoke image would
+# also be undesirable.
+#
+# Usage:
+#   make smoke-cuda                                          # build + run the matrix
+#   make smoke-cuda-shell                                    # interactive poking
+#   docker build -f Dockerfile.cuda -t zsh-dotfiles-cuda .
+#   docker run --rm zsh-dotfiles-cuda
+#   docker run --rm -v "$PWD:/tmp/dotfiles:ro" zsh-dotfiles-cuda   # iterate w/o rebuild
+#
+ARG UBUNTU_VERSION=22.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
+
+# NVIDIA repo slug, derived from UBUNTU_VERSION (22.04 -> ubuntu2204).
+ARG CUDA_REPO_DISTRO=ubuntu2204
+ARG CUDA_REPO_ARCH=x86_64
+# Which toolkit series the happy-path stages install. Only a real nvcc is pulled
+# (~25 MB); the symlink/alternatives machinery lives in the 16 KB
+# cuda-toolkit-<series>-config-common package.
+ARG CUDA_SERIES=13-0
+ENV CUDA_SERIES=${CUDA_SERIES}
+
+# zsh: the module under test. dash + bash: the POSIX snippet's real consumers
+# (~/.profile runs under dash on Ubuntu, ~/.bashrc under bash). g++: nvcc's host
+# compiler.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        zsh dash bash g++ curl wget ca-certificates gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Same network repo the install docs use. Note this also installs NVIDIA's
+# /etc/apt/preferences.d/cuda-repository-pin-600, which pins their whole repo
+# above Ubuntu's default 500 -- the verification script asserts on that.
+RUN wget -q "https://developer.download.nvidia.com/compute/cuda/repos/${CUDA_REPO_DISTRO}/${CUDA_REPO_ARCH}/cuda-keyring_1.1-1_all.deb" \
+        -O /tmp/cuda-keyring.deb \
+    && dpkg -i /tmp/cuda-keyring.deb \
+    && rm -f /tmp/cuda-keyring.deb \
+    && apt-get update
+
+COPY . /tmp/dotfiles
+WORKDIR /tmp/dotfiles
+
+CMD ["/tmp/dotfiles/scripts/cuda-verify-config.sh"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1.4
+# GPU / driver-compatibility verification container (REQUIRES a GPU).
+#
+# Answers the question no CPU-only test can: does a binary built with CUDA
+# toolkit <X> actually RUN on the driver installed on this host? Because the
+# container runtime injects the HOST driver, this is a faithful rehearsal of a
+# toolkit upgrade before installing anything on the host.
+#
+# Requires nvidia-container-toolkit on the host. Two ways to expose the GPU:
+#
+#   CDI (preferred; no daemon.json edit, no docker restart -- Docker 25+):
+#     sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+#     docker run --rm --device nvidia.com/gpu=all zsh-dotfiles-gpu
+#
+#   nvidia runtime (needs `nvidia-ctk runtime configure` + daemon restart):
+#     docker run --rm --gpus all zsh-dotfiles-gpu
+#
+# Usage:
+#   make smoke-gpu                                        # build + run (CDI)
+#   make smoke-gpu-shell                                  # interactive
+#   make smoke-gpu CUDA_IMAGE=nvidia/cuda:12.1.0-devel-ubuntu22.04   # other toolkit
+#
+# Pick CUDA_IMAGE to match the toolkit you intend to install on the host. The
+# script reports the driver's CUDA API level and fails loudly if the toolkit is
+# too new for it.
+ARG CUDA_IMAGE=nvidia/cuda:13.0.0-devel-ubuntu22.04
+FROM ${CUDA_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
+
+# zsh/dash/bash are here for poking at the shell modules by hand in
+# `make smoke-gpu-shell`, e.g.:
+#     source /tmp/dotfiles/home/shell/cuda/custom.zsh && echo $CUDA_HOME
+#
+# Note: scripts/cuda-verify-config.sh does NOT work in this image, and that is
+# expected. It assumes a clean slate and drives its own staged apt install/purge
+# sequence; this base image already ships a CUDA install at /usr/local/cuda, so
+# its Stage 0 ("nothing installed") is false from the start and the staged
+# installs conflict. Use Dockerfile.cuda for module verification and this image
+# only for driver/runtime compatibility.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        zsh dash bash \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /tmp/dotfiles
+WORKDIR /tmp/dotfiles
+
+CMD ["/tmp/dotfiles/scripts/cuda-verify-gpu.sh"]

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,48 @@ smoke-mise-shell:  ## Interactive shell with VERSION_MANAGER=mise for manual ver
 	@echo "\033[0;34mStarting interactive shell with VERSION_MANAGER=mise...\033[0m"
 	VERSION_MANAGER=mise docker compose run --rm smoke-shell
 
+# ---------------------------------------------------------------------------
+# CUDA / GPU verification (ad-hoc; not part of CI)
+#
+# CI runs on macOS only and the cuda sheldon plugin is Linux-gated, so nothing in
+# .github/workflows ever sources home/shell/cuda/*. These targets are the real
+# gate for that code.
+#
+#   smoke-cuda  - no GPU needed. Exercises the shell modules against real NVIDIA
+#                 apt packages, real update-alternatives and real ld.so.conf.d.
+#   smoke-gpu   - needs a GPU + nvidia-container-toolkit. Answers "can my driver
+#                 run binaries built by toolkit X?" before installing X on the host.
+#
+# Override the toolkit under test:
+#   CUDA_SERIES=12-1 make smoke-cuda
+#   CUDA_IMAGE=nvidia/cuda:12.1.0-devel-ubuntu22.04 make smoke-gpu
+#   MIN_DRIVER=580.126.20 make smoke-gpu     # also assert a documented floor
+# ---------------------------------------------------------------------------
+.PHONY: smoke-cuda smoke-cuda-shell smoke-gpu smoke-gpu-shell smoke-cuda-clean
+
+smoke-cuda:  ## Verify the CUDA shell modules against real NVIDIA packages (no GPU required)
+	@echo "\033[0;34mVerifying CUDA shell modules in Docker (CUDA_SERIES=$${CUDA_SERIES:-13-0})...\033[0m"
+	docker compose run --rm --build cuda-verify
+
+smoke-cuda-shell:  ## Interactive shell in the CUDA verification container
+	@echo "\033[0;34mStarting CUDA verification shell...\033[0m"
+	docker compose run --rm --build cuda-verify-shell
+
+smoke-gpu:  ## Verify a CUDA toolkit against the host driver (requires GPU + nvidia-container-toolkit)
+	@echo "\033[0;34mVerifying GPU/driver compatibility (CUDA_IMAGE=$${CUDA_IMAGE:-nvidia/cuda:13.0.0-devel-ubuntu22.04})...\033[0m"
+	@command -v nvidia-smi >/dev/null 2>&1 || { echo "\033[0;31mnvidia-smi not found on the host - no GPU to test.\033[0m"; exit 2; }
+	@nvidia-ctk cdi list >/dev/null 2>&1 || echo "\033[0;33mwarning: no CDI spec found. Run: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml\033[0m"
+	docker compose run --rm --build gpu-verify
+
+smoke-gpu-shell:  ## Interactive shell in the GPU verification container
+	@echo "\033[0;34mStarting GPU verification shell...\033[0m"
+	docker compose run --rm --build gpu-verify-shell
+
+smoke-cuda-clean:  ## Remove the CUDA/GPU verification images
+	@echo "\033[0;34mRemoving CUDA/GPU verification images...\033[0m"
+	-docker rmi chezmoi-cuda-verify chezmoi-cuda-verify-shell chezmoi-gpu-verify chezmoi-gpu-verify-shell 2>/dev/null || true
+	-docker compose rm -f cuda-verify cuda-verify-shell gpu-verify gpu-verify-shell 2>/dev/null || true
+
 .PHONY: smoke-full smoke-full-asdf smoke-full-mise \
         smoke-full-run-asdf smoke-full-run-mise smoke-full-clean
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Read the deep dive in **[docs/architecture.md](docs/architecture.md)** and the e
 | 🖥️ [iTerm2 &amp; macOS](docs/iterm2-and-macos.md) | The self-verifying iTerm2 settings importer, Nerd Fonts, and `~/.osx` |
 | 🧪 [Testing &amp; CI](docs/testing-and-ci.md) | pytest + libtmux, Docker smoke lanes, the 5 GitHub workflows and 8-cell matrix |
 | ⚠️ [Gotchas](docs/gotchas.md) | Candid known warts and cleanup candidates — dead code, inert flags, mis-named scripts |
-| 🎓 [Tutorials](docs/tutorials/README.md) | Hands-on, numbered walkthroughs (00 → 06), newcomer-first with verification steps |
+| 🎓 [Tutorials](docs/tutorials/README.md) | Hands-on, numbered walkthroughs (00 → 07), newcomer-first with verification steps |
 | 🤝 [Contributing](CONTRIBUTING.md) | Dev setup, pre-commit hooks, editing templates, adding a tool module |
 
 ---

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Runtime version management — pick one at install time (see [Version Managers](
 
 Both provision pinned versions of Go, Ruby, Node, Neovim, tmux, shellcheck/shfmt, the Kubernetes toolchain, and more — the exact matrix lives in [docs/version-managers.md](docs/version-managers.md#pinned-tool-versions).
 
-Optional features are prompted at init. **Note:** of the eight boolean prompts, `pyenv`, `opencv`, `cuda`, and `fzf_tab` are live (they change your rendered config); `ruby`, `nodejs`, `k8s`, and `fnm` are recorded but not yet wired to any template — see [Feature Flags](docs/feature-flags.md#chezmoi-feature-booleans) and [Gotchas](docs/gotchas.md#6-several-feature-flags-are-inert). The newest, [`fzf_tab`](docs/fzf-tab.md), is off by default and swaps zsh's completion menu for an fzf selector when enabled.
+Optional features are prompted at init. **Note:** of the eight boolean prompts, `pyenv`, `opencv`, and `fzf_tab` are live (they change your rendered config); `ruby`, `nodejs`, `k8s`, `fnm`, and `cuda` are recorded but not yet wired to any template — see [Feature Flags](docs/feature-flags.md#chezmoi-feature-booleans) and [Gotchas](docs/gotchas.md#6-several-feature-flags-are-inert). The newest, [`fzf_tab`](docs/fzf-tab.md), is off by default and swaps zsh's completion menu for an fzf selector when enabled.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,77 @@ services:
       - HOMEBREW_NO_ANALYTICS=1
       - VERSION_MANAGER=${VERSION_MANAGER:-asdf}
 
+  # CUDA shell-module verification against real NVIDIA apt packages (no GPU).
+  # Jammy on purpose: NVIDIA's repos are per-distro and the host is 22.04.
+  cuda-verify:
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+      args:
+        CUDA_SERIES: ${CUDA_SERIES:-13-0}
+    container_name: dotfiles-cuda-verify
+    environment:
+      - TERM=xterm-256color
+      - CUDA_SERIES=${CUDA_SERIES:-13-0}
+
+  cuda-verify-shell:
+    build:
+      context: .
+      dockerfile: Dockerfile.cuda
+      args:
+        CUDA_SERIES: ${CUDA_SERIES:-13-0}
+    container_name: dotfiles-cuda-verify-shell
+    environment:
+      - TERM=xterm-256color
+      - CUDA_SERIES=${CUDA_SERIES:-13-0}
+    stdin_open: true
+    tty: true
+    entrypoint: /bin/bash
+
+  # GPU / driver-compatibility verification. REQUIRES nvidia-container-toolkit.
+  #
+  # The `devices` entry below is the CDI form, which needs no daemon.json edit and
+  # no docker restart (Docker 25+ with CDI enabled -- check `docker info | grep -i cdi`).
+  # Generate the spec once: sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+  #
+  # If you configured the nvidia *runtime* instead
+  # (`sudo nvidia-ctk runtime configure --runtime=docker` + daemon restart), delete
+  # the `devices` list and use this instead:
+  #     deploy:
+  #       resources:
+  #         reservations:
+  #           devices:
+  #             - driver: nvidia
+  #               count: all
+  #               capabilities: [gpu]
+  gpu-verify:
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        CUDA_IMAGE: ${CUDA_IMAGE:-nvidia/cuda:13.0.0-devel-ubuntu22.04}
+    container_name: dotfiles-gpu-verify
+    devices:
+      - nvidia.com/gpu=all
+    environment:
+      - TERM=xterm-256color
+      - MIN_DRIVER=${MIN_DRIVER:-}
+
+  gpu-verify-shell:
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+      args:
+        CUDA_IMAGE: ${CUDA_IMAGE:-nvidia/cuda:13.0.0-devel-ubuntu22.04}
+    container_name: dotfiles-gpu-verify-shell
+    devices:
+      - nvidia.com/gpu=all
+    environment:
+      - TERM=xterm-256color
+    stdin_open: true
+    tty: true
+    entrypoint: /bin/bash
+
   # Interactive shell for debugging failed tests
   smoke-shell:
     build:

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ The [tutorial track](tutorials/README.md) is a numbered, goal-oriented path — 
 | 04 | [Switch version manager](tutorials/04-switch-version-manager.md) | A shell running on mise |
 | 05 | [Run smoke tests locally](tutorials/05-run-smoke-tests-locally.md) | CI parity on your laptop |
 | 06 | [Customize iTerm2](tutorials/06-customize-iterm2.md) | Version-controlled terminal settings |
+| 07 | [Verify CUDA before applying](tutorials/07-verify-cuda-before-applying.md) | Confidence in your CUDA/driver state before changing it |
 
 ## Conventions
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -19,8 +19,8 @@ These boolean flags are collected by `home/.chezmoi.yaml.tmpl` and stored in you
 `data:`. Each is prompted with `promptBool` in interactive runs (default `false`).
 
 > ⚠️ **Not every flag is wired up.** Toggling a flag only matters if some template actually
-> reads it. As of this writing, **`pyenv`**, **`opencv`**, **`cuda`**, and **`fzf_tab`** are
-> consumed by a `.tmpl`; **`ruby`, `nodejs`, `k8s`, and `fnm` are recorded but inert** — no
+> reads it. As of this writing, **`pyenv`**, **`opencv`**, and **`fzf_tab`** are
+> consumed by a `.tmpl`; **`ruby`, `nodejs`, `k8s`, `fnm`, and `cuda` are recorded but inert** — no
 > template reads them, so flipping them changes nothing about what gets installed. This is
 > verifiable with `grep -rl '\.<flag>' home/ --include='*.tmpl'`. See
 > [Gotchas](gotchas.md#6-several-feature-flags-are-inert) for the full analysis. The table's
@@ -30,7 +30,7 @@ These boolean flags are collected by `home/.chezmoi.yaml.tmpl` and stored in you
 |------|---------|--------|---------------------------------|
 | `pyenv` | `false` | ✅ **Live** | `home/compat.sh.tmpl`, `home/compat.bash.tmpl`, `home/.chezmoiscripts/run_onchange_before_02-macos-install-pyenv.sh.tmpl`, `run_before-00-prereq-{centos,ubuntu}-pyenv.sh.tmpl` |
 | `opencv` | `false` | ✅ **Live (Linux)** | `home/.chezmoiscripts/run_onchange_before_02-{centos,ubuntu}-install-opencv-deps.sh.tmpl` |
-| `cuda` | `false` | ✅ **Live (Ubuntu/Oracle)** | `home/dot_sheldon/plugins.toml.tmpl`, `home/private_dot_config/sheldon/plugins.toml.tmpl` (loads the `cuda` module) |
+| `cuda` | `false` | ⚠️ **Inert** | *(no `.tmpl` reads `.cuda`; the `cuda` shell module is gated on `.chezmoi.os` + `.chezmoi.osRelease.name`, not on this flag)* |
 | `fzf_tab` | `false` | ✅ **Live** | `home/dot_sheldon/plugins.toml.tmpl` (+ `private_dot_config/sheldon/`) — gates the fzf-tab plugin lane. Env override `CM_fzf_tab=true`; runtime kill-switch file `~/.config/zsh-dotfiles/fzf-tab-disabled`. See [fzf-tab](fzf-tab.md) |
 | `ruby` | `false` | ⚠️ **Inert** | *(no `.tmpl` reads `.ruby`)* |
 | `nodejs` | `false` | ⚠️ **Inert** | *(no `.tmpl` reads `.nodejs`)* |

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -17,7 +17,7 @@
 | 3 | `pytest-rerunfailures` pinned twice in [`requirements-test.txt`](../requirements-test.txt) | Harmless but sloppy | Delete the duplicate line |
 | 4 | [`run_onchange_before_99-macos-osx-settings.sh.tmpl`](../home/.chezmoiscripts/run_onchange_before_99-macos-osx-settings.sh.tmpl) is a comment-only stub | Implies macOS defaults auto-apply; they don't | Wire up `~/.osx --no-restart`, or remove the stub |
 | 5 | README structure tree had stale paths | Confusing onboarding | Addressed in this docs pass |
-| 6 | `ruby`, `nodejs`, `k8s`, `fnm` feature flags are **inert** — recorded in chezmoi data but read by no template | Toggling them silently does nothing | Wire them to real gates, or drop the prompts |
+| 6 | `ruby`, `nodejs`, `k8s`, `fnm`, `cuda` feature flags are **inert** — recorded in chezmoi data but read by no template | Toggling them silently does nothing | Wire them to real gates, or drop the prompts |
 | 7 | `run_before-00-*` / `run_after-00-*` scripts use a **hyphen**, not the `before_`/`after_` underscore chezmoi requires | They run in the "during" bucket, interleaved with file writes — not strictly before/after | Rename to `run_before_00-…` / `run_after_00-…` |
 
 ---
@@ -85,7 +85,7 @@ The previous `README.md` structure tree referenced `ai_docs/summaries/` (the rea
 
 ## 6. Several feature flags are inert
 
-Of the seven boolean feature flags collected at `chezmoi init` (`ruby`, `pyenv`, `nodejs`, `k8s`, `opencv`, `fnm`, `cuda`), **four are never read by any template**. They are dutifully stored in `~/.config/chezmoi/chezmoi.yaml` but consulted by nothing, so toggling them has no effect.
+Of the seven boolean feature flags collected at `chezmoi init` (`ruby`, `pyenv`, `nodejs`, `k8s`, `opencv`, `fnm`, `cuda`), **five are never read by any template**. They are dutifully stored in `~/.config/chezmoi/chezmoi.yaml` but consulted by nothing, so toggling them has no effect.
 
 Verify it yourself — only `.tmpl` files can act on a flag:
 
@@ -99,7 +99,7 @@ done
 |------|--------------------|---------|
 | `pyenv` | ✅ 5 files (compat scripts + install scripts) | **Live** — a real, cross-cutting gate |
 | `opencv` | ✅ 2 Linux install scripts | **Live** on Linux only |
-| `cuda` | ✅ sheldon `plugins.toml.tmpl` (×2) | **Live** (and the `cuda` module is itself Ubuntu/Oracle-gated) |
+| `cuda` | ❌ none | **Inert** — the `cuda` shell module is gated on `.chezmoi.os` + `.chezmoi.osRelease.name`, never on `.cuda` |
 | `ruby` | ❌ none | **Inert** |
 | `nodejs` | ❌ none | **Inert** |
 | `k8s` | ❌ none | **Inert** — the only `.k8s` hit in the tree is `events.k8s.io` inside a kubectl loop |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -159,7 +159,7 @@ All prompts surfaced during first-time `chezmoi init` (from [`home/.chezmoi.yaml
 | `pyenv` | bool | `false` | — | Install pyenv for Python version management |
 | `nodejs` | bool | `false` | — | Install Node.js via the selected version manager |
 | `k8s` | bool | `false` | — | Install the Kubernetes toolchain |
-| `cuda` | bool | `false` | — | Install CUDA support |
+| `cuda` | bool | `false` | — | Recorded only; no template reads it (the `cuda` shell module is OS-gated) |
 | `fnm` | bool | `false` | — | Install fnm (Fast Node Manager) |
 | `opencv` | bool | `false` | — | Install OpenCV system dependencies |
 

--- a/docs/shell-loading.md
+++ b/docs/shell-loading.md
@@ -102,12 +102,29 @@ Plugins load in the order they appear in [`plugins.toml.tmpl`](../home/dot_sheld
 | 18 | `fast-syntax-highlighting` | [zdharma-continuum/fast-syntax-highlighting](https://github.com/zdharma-continuum/fast-syntax-highlighting) | **defer-more** | Faster highlighter |
 | 19 | `zsh-dircolors-solarized` | [joel-porquet/zsh-dircolors-solarized](https://github.com/joel-porquet/zsh-dircolors-solarized) | **defer-more** | Solarized `LS_COLORS` |
 | 20 | `compinit` | `home/shell/compinit.zsh` | **defer** | Daily-cached completion init (`compinit`) |
-| 21 | *(Ubuntu/Oracle only)* `cuda` | `home/shell/cuda/custom.zsh` | immediate | CUDA env |
+| 21 | *(Ubuntu/Oracle only)* `cuda` | `home/shell/cuda/custom.zsh` | immediate | Detects the installed CUDA toolkit; no-op if none |
 | 22 | `bossaliases` | `home/shell/customs/aliases.zsh` | immediate | The big custom alias/function library |
 | 23 | `aliases` | `home/shell/**/aliases.zsh` | immediate | Per-tool aliases |
 | 24 | `boss_fzf` | inline `source ~/.fzf.zsh` | immediate | fzf keybindings & completion (macOS, Ubuntu/Oracle) |
 
 > **Note the exceptions to the "highlighting is deferred" rule.** `zsh-autosuggestions` (14) and `zsh-hooks` (15) are *immediate* — they are declared without `apply = ["defer"]`. `compinit` (20) is deferred and cached daily, which is a major startup win.
+
+> **The `cuda` module (21) discovers its version at shell start.** It does not hardcode a toolkit
+> version. It prefers `/usr/local/cuda` — the symlink `update-alternatives` maintains — then falls
+> back to the highest-numbered `/usr/local/cuda-<major>.<minor>` still on disk, and does nothing at
+> all when no toolkit is installed. That last case is normal on a machine whose CUDA comes from pip
+> wheels: PyTorch resolves `libcu*`/`libcublas` out of `site-packages/nvidia/*`, never from
+> `/usr/local/cuda`. It exports `CUDA_HOME` and `CUDA_PATH` (CMake's `FindCUDAToolkit` looks for the
+> latter) and adds exactly one `PATH` entry, containment-guarded so a re-source cannot duplicate it.
+>
+> It deliberately does **not** set `LD_LIBRARY_PATH`. The `.deb` packages register
+> `/usr/local/cuda/targets/x86_64-linux/lib` via `/etc/ld.so.conf.d/000_cuda.conf`, so the dynamic
+> linker already finds the libraries; because `LD_LIBRARY_PATH` outranks the `ldconfig` cache, setting
+> it would only create a way for a stale entry to shadow the correct libraries.
+>
+> `ZSH_DOTFILES_CUDA_ROOT` overrides the search prefix so the behaviour can be exercised against a
+> throwaway tree. Leave it unset in normal use. The POSIX equivalent for `~/.profile` and `~/.bashrc`
+> lives in `home/shell/cuda/posix-env.sh` and is inlined into `home/compat.{sh,bash}.tmpl`.
 
 ### What that looks like on the timeline
 

--- a/docs/testing-and-ci.md
+++ b/docs/testing-and-ci.md
@@ -10,6 +10,7 @@ Comprehensive reference for the testing framework, GitHub workflows, Docker smok
 - [GitHub Actions Job Pipeline](#github-actions-job-pipeline)
 - [Pre-Commit Hooks](#pre-commit-hooks)
 - [Docker Smoke Tests](#docker-smoke-tests)
+- [CUDA / GPU Verification Rigs](#cuda--gpu-verification-rigs)
 
 ---
 
@@ -54,6 +55,18 @@ VERSION_MANAGER=mise make smoke
 
 # Clean up Docker images/containers
 make smoke-clean
+```
+
+### CUDA / GPU Verification (ad-hoc)
+
+Nothing in CI covers `home/shell/cuda/` — CI is macOS-only and those modules are Linux-gated.
+
+```bash
+# Verify the CUDA shell modules against real NVIDIA packages (no GPU needed)
+make smoke-cuda
+
+# Verify a CUDA toolkit works against this host's driver (needs a GPU)
+make smoke-gpu
 ```
 
 ---
@@ -148,6 +161,23 @@ Defined in the [`Makefile`](../Makefile). Note that only some targets are declar
 | `smoke-mise` | Full with `VERSION_MANAGER=mise` | Test mise version manager lane | `make smoke-mise` |
 | `smoke-asdf-shell` | Interactive with `VERSION_MANAGER=asdf` | Interactive asdf debugging | `make smoke-asdf-shell` |
 | `smoke-mise-shell` | Interactive with `VERSION_MANAGER=mise` | Interactive mise debugging | `make smoke-mise-shell` |
+
+### CUDA / GPU Verification Targets (ad-hoc, not in CI)
+
+| Target | Runs | Needs a GPU? | Example |
+|--------|------|--------------|---------|
+| `smoke-cuda` | Shell modules vs. real NVIDIA apt packages | No | `CUDA_SERIES=12-1 make smoke-cuda` |
+| `smoke-cuda-shell` | Interactive bash in that container | No | `make smoke-cuda-shell` |
+| `smoke-gpu` | A CUDA toolkit vs. the host's driver | **Yes** | `MIN_DRIVER=580.126.20 make smoke-gpu` |
+| `smoke-gpu-shell` | Interactive bash with the GPU attached | **Yes** | `make smoke-gpu-shell` |
+| `smoke-cuda-clean` | None (cleanup) | No | `make smoke-cuda-clean` |
+
+**These are the only real coverage for `home/shell/cuda/`.** CI runs on macOS only
+([`tests.yml`](../.github/workflows/tests.yml) matrix is `macos-14`/`macos-15`) and the `cuda`
+sheldon plugin is gated on `.chezmoi.os == "linux"`, so no CI job ever sources those modules. The
+pytest suite does not cover them either.
+
+See [Docker Smoke Tests](#docker-smoke-tests) for what each rig actually asserts.
 
 ### Pre-Provisioned Image Targets (DOCKER_BUILDKIT=1 required)
 
@@ -464,6 +494,71 @@ VERSION_MANAGER=mise docker compose run --rm smoke build
 # Interactive debugging
 docker compose run --rm smoke-shell /bin/zsh
 ```
+
+---
+
+## CUDA / GPU Verification Rigs
+
+Two separate ad-hoc rigs, because they answer different questions. Neither runs in CI.
+
+### Why separate from the standard smoke image
+
+[`Dockerfile`](../Dockerfile) is `ubuntu:24.04`; these are `ubuntu:22.04`, because NVIDIA's apt
+repos are per-distro (`ubuntu2204` vs `ubuntu2404`) and must match the host being modelled. Adding
+NVIDIA's repo to the standard image would also drag in
+`/etc/apt/preferences.d/cuda-repository-pin-600`, which pins their whole repo above Ubuntu's default
+500 — not something the normal smoke lane should inherit.
+
+### `Dockerfile.cuda` — module verification, no GPU
+
+`make smoke-cuda` → [`scripts/cuda-verify-config.sh`](../scripts/cuda-verify-config.sh). The modules
+only inspect the filesystem, so no GPU or `nvidia-container-toolkit` is needed. It installs and
+purges **real** NVIDIA packages, so it refuses to run outside a container unless `FORCE=1`.
+
+Costs kilobytes, not gigabytes: `cuda-toolkit-<series>-config-common` is ~16 KB and owns the
+`/usr/local/cuda` symlink, the `update-alternatives` registration and
+`/etc/ld.so.conf.d/000_cuda.conf`. Only `cuda-nvcc-<series>` (~25 MB) is pulled for the happy path.
+
+| Stage | Asserts |
+|-------|---------|
+| 0 | Clean slate → modules no-op, `PATH` untouched, exit 0, no diagnostics |
+| 1 | Our apt pin beats NVIDIA's 600 pin, **with a negative control**, and does not collaterally block `nvidia-container-toolkit` |
+| 2 | Real alternatives for toolkits lacking `bin/` are rejected |
+| 3 | The alternatives-managed symlink is preferred; `nvcc` reachable |
+| 3b | Numeric ordering against real dirs (`cuda-9.0` must not beat `cuda-13.0`) |
+| 4 | `cuda-11` / `cuda-12` major-version aliases are excluded |
+| 5 | `ldconfig` resolves `libcudart` with `LD_LIBRARY_PATH` unset |
+| 6 | Purging stale toolkits still resolves the survivor |
+| 7 | A dangling `/usr/local/cuda` mid-purge falls back correctly |
+| 8 | Full purge leaves gutted dirs behind → modules still no-op |
+
+### `Dockerfile.gpu` — driver compatibility, GPU required
+
+`make smoke-gpu` → [`scripts/cuda-verify-gpu.sh`](../scripts/cuda-verify-gpu.sh). Answers the one
+question no CPU-only test can: **can the host's driver run binaries built by toolkit X?** Because the
+container runtime injects the host driver, pointing `CUDA_IMAGE` at the toolkit you intend to install
+rehearses that upgrade before touching the host.
+
+The **PTX JIT** stage is the sharpest check — minor-version compatibility works by the driver
+JIT-compiling the toolkit's PTX at load time, so a too-old driver fails there even when a prebuilt
+cubin loads fine. It also fails loudly if the toolkit has dropped your GPU's architecture.
+
+```sh
+# One-time host setup. CDI needs no daemon.json edit and no docker restart
+# (Docker 25+; confirm with: docker info | grep -i cdi).
+sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+
+make smoke-gpu
+CUDA_IMAGE=nvidia/cuda:12.1.0-devel-ubuntu22.04 make smoke-gpu   # rehearse a different toolkit
+MIN_DRIVER=580.126.20 make smoke-gpu                             # also assert a documented floor
+```
+
+If the GPU is not exposed the script exits 2 with an actionable message rather than passing silently.
+
+> `scripts/cuda-verify-config.sh` intentionally does **not** work in this image: the base already
+> ships a CUDA install, so its clean-slate Stage 0 is false and its staged installs conflict. Use
+> `Dockerfile.cuda` for module verification.
 
 ---
 

--- a/docs/tutorials/07-verify-cuda-before-applying.md
+++ b/docs/tutorials/07-verify-cuda-before-applying.md
@@ -1,0 +1,568 @@
+# Tutorial 07: Verify CUDA Before Applying
+
+> Inspect your CUDA/driver state by hand, prove the shell module resolves correctly, and rehearse a toolkit upgrade in a GPU-attached container — all before you touch your host's actual toolkit.
+
+**See also:** [docs/testing-and-ci.md](../testing-and-ci.md#cuda--gpu-verification-rigs) (the automated rigs this tutorial explains) · [docs/shell-loading.md](../shell-loading.md) (the cuda module in the load order) · [Tutorial 05: Run Smoke Tests Locally](05-run-smoke-tests-locally.md) · [Tutorials index](README.md)
+
+---
+
+## What you'll learn
+
+- How [`home/shell/cuda/custom.zsh`](../../home/shell/cuda/custom.zsh) decides which toolkit to use, and how to prove it on your own machine
+- Why the module deliberately never sets `LD_LIBRARY_PATH`, and how to confirm that's safe on your host
+- How to rehearse every state the module can be in — dangling symlink, stale minor versions, half-removed packages — using a disposable fake root, with no changes to `/usr/local`
+- How to expose your GPU to a container without editing `daemon.json` or restarting Docker, so you can test a toolkit upgrade against your real driver before installing it
+- Why a PTX-only build is the sharpest compatibility check you can run, and what it actually proves
+- Which `apt` package names and pin patterns have burned people, with the commands to check before you touch anything
+
+**Prerequisites:** Ubuntu 22.04 (or similar) with an NVIDIA GPU and driver already installed; `zsh` (ships with this repo). The container sections additionally need [Docker](https://www.docker.com/) and [`nvidia-container-toolkit`](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) — skip Steps 5–6 if you just want the shell-module checks.
+
+**Time estimate:** 30–45 minutes end to end; 5 minutes if you only do the module checks (Steps 1–3).
+
+---
+
+## Why do this by hand when `make smoke-cuda` / `make smoke-gpu` already exist?
+
+They exist precisely because [nothing in CI covers `home/shell/cuda/`](../testing-and-ci.md#cuda--gpu-verification-rigs) — the GitHub Actions matrix is macOS-only, and the `cuda` sheldon plugin is gated on `.chezmoi.os == "linux"`. The Docker rigs are the real gate for that code, and for most changes you should just run them.
+
+This tutorial is the manual counterpart. Run the rigs to get a pass/fail; run this tutorial when the rig fails and you need to know *which* check broke, or when you're about to change your CUDA setup and want to probe a scenario the rigs don't happen to cover (a specific driver number, a specific toolkit series, your actual host's directory layout).
+
+---
+
+## Step 1: Read the module before you trust it
+
+Open [`home/shell/cuda/custom.zsh`](../../home/shell/cuda/custom.zsh) and [`home/shell/cuda/posix-env.sh`](../../home/shell/cuda/posix-env.sh). The zsh version loads **immediately** — step 21 of the [load order](../shell-loading.md) — so it only uses builtins and globbing, no subprocesses, and it runs on every new shell whether or not you have a GPU.
+
+```mermaid
+flowchart TD
+    A["Module sourced"] --> B{"${root}/cuda/bin exists?<br/>(-d follows the symlink)"}
+    B -- yes --> C["CUDA_HOME = ${root}/cuda"]
+    B -- no --> D{"any ${root}/cuda-M.N/bin<br/>on disk? (M.N shape only)"}
+    D -- yes --> E["CUDA_HOME = highest M.N,<br/>numeric sort"]
+    D -- no --> F["no-op: CUDA_HOME/CUDA_PATH<br/>unset, PATH untouched, exit 0"]
+```
+
+The resolution order, in the module's own words:
+
+1. Prefer `${root}/cuda` — the symlink [`update-alternatives`](https://manpages.debian.org/bookworm/dpkg/update-alternatives.1.en.html) maintains. `[[ -d ... ]]` follows symlinks, so a **dangling** symlink (target deleted, link still present — the real transient state mid-`apt purge`) correctly fails this check.
+2. Otherwise, glob `${root}/cuda-[0-9]*.[0-9]*(N-/)` — the [glob qualifiers](https://zsh.sourceforge.io/Doc/Release/Expansion.html#Glob-Qualifiers) mean dirs/symlinks-to-dirs only (`-/`), silent if none match (`N`) — and walk them in **reverse numeric** order (`${(On)candidates}`) looking for the first one with a `bin/`. The `<major>.<minor>` glob shape is deliberate: it matches `cuda-13.0` but not the `update-alternatives` major-version aliases `cuda-11` / `cuda-12` / `cuda-13`, which are pointers to a toolkit, not toolkits themselves.
+3. Otherwise do nothing — no `CUDA_HOME`, no `PATH` change, exit 0.
+
+`root` defaults to `/usr/local` but can be overridden by `ZSH_DOTFILES_CUDA_ROOT` — that's the hook this whole tutorial depends on: it lets you exercise the real logic against a throwaway directory tree instead of your actual `/usr/local`.
+
+Once a `cuda_home` is picked, the module exports `CUDA_HOME` and `CUDA_PATH` (CMake's `FindCUDAToolkit` looks for the latter) and adds `${cuda_home}/bin` to `PATH` — guarded by a `case ":${PATH}:" in *":${cuda_home}/bin:"*)` check, so re-sourcing the module (a new tab, `exec zsh`, whatever) cannot grow `PATH` on every load.
+
+The POSIX sibling, `posix-env.sh` (inlined into [`home/compat.sh.tmpl`](../../home/compat.sh.tmpl) and [`home/compat.bash.tmpl`](../../home/compat.bash.tmpl) for `~/.profile`/`~/.bashrc`), is deliberately dumber: it trusts **only** the `update-alternatives` symlink, with no highest-version fallback. POSIX `sh` can't version-sort without spawning a subprocess, and a lexical "last match" would rank `cuda-9.0` above `cuda-13.0` — so if the symlink is broken, `sh`/`bash` sessions just get no CUDA env. That's an accepted degradation: nobody does CUDA work from a `dash` login shell here.
+
+**Check what it resolves on your actual host right now:**
+
+```sh
+zsh -f -c 'source "$(chezmoi source-path)/shell/cuda/custom.zsh"
+echo "CUDA_HOME=${CUDA_HOME:-<none>}"
+echo "CUDA_PATH=${CUDA_PATH:-<none>}"
+echo $PATH | tr ":" "\n" | grep cuda'
+
+update-alternatives --display cuda
+```
+
+> **Note the path.** `chezmoi source-path` already ends in `.../chezmoi/home`, because
+> [`.chezmoiroot`](../../.chezmoiroot) redirects the source root to `home/`. So the module is at
+> `$(chezmoi source-path)/shell/cuda/custom.zsh` — writing `.../home/shell/...` doubles the
+> `home/` and silently fails to source anything.
+
+If a toolkit is installed, you'll see `CUDA_HOME`/`CUDA_PATH` pointing at `/usr/local/cuda` and `update-alternatives --display cuda` showing the same target as its "currently selected" link. If nothing is installed (common if your CUDA support comes entirely from pip wheels — see Step 7), both print `<none>` and the `grep cuda` line prints nothing, which is the correct, silent no-op.
+
+---
+
+## Step 2: Confirm `LD_LIBRARY_PATH` really isn't needed
+
+This is the part that looks wrong until you check it. Most CUDA tutorials tell you to export `LD_LIBRARY_PATH=/usr/local/cuda/lib64` — this module never does, on purpose.
+
+`/usr/local/cuda-X/lib64` is a **symlink** to `targets/x86_64-linux/lib`, and the `.deb` packages already register that real directory with the dynamic linker via a drop-in [`ld.so.conf.d`](https://man7.org/linux/man-pages/man8/ld.so.8.html) file:
+
+```sh
+readlink -f /usr/local/cuda/lib64
+cat /etc/ld.so.conf.d/000_cuda.conf
+```
+
+So `ldconfig`'s cache already knows where `libcudart` lives, with `LD_LIBRARY_PATH` unset:
+
+```sh
+echo "${LD_LIBRARY_PATH:-<unset>}"
+ldconfig -p | grep -c libcudart
+```
+
+A non-zero count with `LD_LIBRARY_PATH` unset confirms it. NVIDIA's own [installation guide](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html) says the variable is only needed for **runfile** installs (which don't register with `ldconfig`) — not for the `.deb`/apt path this repo uses.
+
+The reason this module treats it as a trap rather than a no-op: `LD_LIBRARY_PATH` **outranks** the `ldconfig` cache in the linker's search order. A stale value left over from an old toolkit install can silently shadow the correct library — for example, forcing an old `libcublas.so` from `/usr/local/cuda-11.8/lib64` into a process that actually wants the newer one `ldconfig` would have handed it. You can see the shadowing mechanism directly if you have more than one toolkit series on disk:
+
+```sh
+# If you have two toolkit series installed, compare where ldconfig resolves
+# a library versus where a manually-set LD_LIBRARY_PATH would pull it from:
+ldconfig -p | grep libcublas
+LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64 ldd $(command -v nvcc 2>/dev/null || echo /bin/true) 2>/dev/null
+```
+
+The module's design avoids ever creating that footgun: no `LD_LIBRARY_PATH` is set, so there's nothing to go stale.
+
+---
+
+## Step 3: Rehearse every module state with a disposable fake root
+
+`ZSH_DOTFILES_CUDA_ROOT` lets you point the module at any directory tree, so you can build fake toolkit layouts and watch the real resolution logic run against them — no `sudo`, no touching `/usr/local`.
+
+**One habit that matters here: always use `env -i` and a fresh `zsh -f`.** A normal shell inherits `PATH` (and possibly `LD_LIBRARY_PATH`) from your interactive session, which silently contaminates the result — during development, this produced a passing-looking result that was actually just leftover state from the parent shell. `env -i` clears the environment entirely; `zsh -f` skips your own `.zshrc`/plugins.
+
+Set up once:
+
+```sh
+DOTFILES="$(chezmoi source-path)"     # already ends in .../chezmoi/home (see .chezmoiroot)
+ZMOD="${DOTFILES}/shell/cuda/custom.zsh"
+PMOD="${DOTFILES}/shell/cuda/posix-env.sh"
+root=$(mktemp -d)
+
+# Sanity-check the paths before relying on them:
+[ -r "$ZMOD" ] && [ -r "$PMOD" ] && echo "modules found" || echo "check DOTFILES"
+```
+
+**Several toolkits + a valid symlink → prefers the symlink:**
+
+```sh
+mkdir -p "$root"/cuda-11.8/bin "$root"/cuda-13.0/bin
+ln -s "$root"/cuda-13.0 "$root"/cuda
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; echo CUDA_HOME=\$CUDA_HOME"
+# CUDA_HOME=/tmp/tmp.XXXXXXXXXX/cuda
+```
+
+**Dangling symlink (target deleted — the real mid-purge transient state) → falls back to the highest real toolkit:**
+
+```sh
+rm "$root"/cuda
+ln -s "$root"/cuda-does-not-exist "$root"/cuda
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; echo CUDA_HOME=\$CUDA_HOME"
+# CUDA_HOME=/tmp/tmp.XXXXXXXXXX/cuda-13.0
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    dash -c ". '$PMOD'; echo CUDA_HOME=\${CUDA_HOME:-NONE}"
+# CUDA_HOME=NONE  -- posix-env.sh trusts only the symlink, no fallback
+```
+
+**`cuda-9.0` alongside `cuda-13.0`, no symlink (the numeric-sort trap) → picks 13.0, not 9.0:**
+
+```sh
+rm "$root"/cuda
+mkdir -p "$root"/cuda-9.0/bin
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; echo CUDA_HOME=\$CUDA_HOME"
+# CUDA_HOME=/tmp/tmp.XXXXXXXXXX/cuda-13.0
+```
+
+**Self-check: why `(On)` and not `(O)`.** Prove the trap directly, without the module, using zsh's own [parameter expansion flags](https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion-Flags):
+
+```sh
+zsh -c 'a=(cuda-9.0 cuda-13.0 cuda-11.8)
+print -l ${(O)a}     # plain reverse sort is LEXICAL
+print -l ${(On)a}    # (n) makes it NUMERIC'
+```
+
+```text
+cuda-9.0
+cuda-13.0
+cuda-11.8
+cuda-13.0
+cuda-11.8
+cuda-9.0
+```
+
+`${(O)a}` (lexical) ranks `cuda-9.0` first — exactly the wrong answer. `${(On)a}` (numeric) ranks `cuda-13.0` first — what the module actually uses.
+
+**Major-version aliases present → ignored:**
+
+```sh
+mkdir -p "$root"/cuda-13/bin   # update-alternatives-style alias, not a real toolkit
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; echo CUDA_HOME=\$CUDA_HOME"
+# CUDA_HOME=/tmp/tmp.XXXXXXXXXX/cuda-13.0  -- cuda-13 never entered the glob
+
+zsh -f -c "print -l ${root}/cuda-[0-9]*.[0-9]*(N-/)"
+# lists cuda-11.8, cuda-13.0, cuda-9.0 -- cuda-13 is absent from the match set
+```
+
+**Directory exists but `bin/` is missing (a half-removed package) → rejected:**
+
+```sh
+root2=$(mktemp -d)
+mkdir -p "$root2"/cuda-12.1     # no bin/ underneath
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root2" \
+    zsh -f -c "source '$ZMOD'; echo CUDA_HOME=\${CUDA_HOME:-NONE}"
+# CUDA_HOME=NONE
+```
+
+**Nothing installed → silent no-op, exit 0, `PATH` untouched:**
+
+```sh
+root3=$(mktemp -d)
+
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root3" \
+    zsh -f -c "source '$ZMOD'; echo \"CUDA_HOME=\${CUDA_HOME:-NONE} PATH=\$PATH\""
+echo "exit=$?"
+# CUDA_HOME=NONE PATH=/usr/bin:/bin
+# exit=0
+```
+
+**Sourced twice → exactly one `PATH` entry:**
+
+```sh
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; source '$ZMOD'
+    print -r -- \${#\${(M)\${(s.:.)PATH}:#*cuda*}}"
+# 1
+```
+
+Clean up the fixtures when you're done — they're in `mktemp -d` output, so they're plain temp directories, not anything precious.
+
+---
+
+## Step 4: Read NVIDIA's two compatibility tables correctly
+
+Before touching your toolkit, know which of NVIDIA's two tables actually applies — conflating them is how people end up either over-cautious or under-prepared:
+
+- **Per-release minimum**, from ["CUDA Toolkit and Corresponding Driver Versions"](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html) in the [release notes](https://docs.nvidia.com/cuda/archive/13.0.3/cuda-toolkit-release-notes/index.html): the driver version NVIDIA states you need for *that specific* toolkit build. For example, CUDA 13.0 GA needs ≥ 580.65.06, 13.0 Update 3 needs ≥ 580.126.20, and CUDA 13.3 Update 1 needs ≥ 610.43.02.
+- **Minor-version-compatibility minimum**, from [CUDA Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/): the much lower floor that applies across an entire major series because of the PTX-JIT mechanism covered in Step 6. For CUDA 13.x, that floor is driver ≥ 580.
+
+So a driver at **580.173.02** fully satisfies every CUDA 13.0 point release under the first table, but falls short of CUDA 13.3's stated requirement — both statements are true at once, about different tables. Check your own numbers rather than guessing:
+
+```sh
+nvidia-smi --query-gpu=driver_version --format=csv,noheader
+```
+
+Then compare that number against the *specific* toolkit version's release notes page, not just the major series.
+
+---
+
+## Step 5: Expose your GPU to a container without restarting Docker
+
+The rehearsal in Step 6 needs the GPU inside a container. [`nvidia-container-toolkit`](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) is what wires that up; if you already added NVIDIA's apt repo (via `cuda-keyring`), it's available from the same network repo with no extra setup.
+
+```sh
+sudo apt-get install -y nvidia-container-toolkit
+```
+
+There are two ways to attach the GPU to a container:
+
+**CDI (preferred).** The [Container Device Interface](https://github.com/cncf-tags/container-device-interface) is a vendor-neutral spec for exposing devices to containers; Docker discovers specs from `/etc/cdi` and `/var/run/cdi`. No `daemon.json` edit, and no Docker restart — so any containers you already have running are left alone. Needs Docker 25+:
+
+```sh
+docker info | grep -i -A1 cdi          # confirm CDI support
+sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+nvidia-ctk cdi list                     # verify the spec was written
+```
+
+```text
+time="..." level=info msg="Found 3 CDI devices"
+nvidia.com/gpu=0
+nvidia.com/gpu=GPU-6e7a0c22-0357-e89e-e18a-f29f86ef8de1
+nvidia.com/gpu=all
+```
+
+`docker info` should then list the spec directories and the discovered devices:
+
+```text
+ CDI spec directories:
+  /etc/cdi
+  /var/run/cdi
+ Discovered Devices:
+  cdi: nvidia.com/gpu=0
+  cdi: nvidia.com/gpu=GPU-6e7a0c22-0357-e89e-e18a-f29f86ef8de1
+  cdi: nvidia.com/gpu=all
+```
+
+Use it with `--device`:
+
+```sh
+docker run --rm --device nvidia.com/gpu=all nvidia/cuda:13.0.0-devel-ubuntu22.04 nvidia-smi -L
+```
+
+**nvidia runtime (the older path).** Requires a `daemon.json` edit and a Docker restart — which *does* interrupt any containers currently running:
+
+```sh
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker      # interrupts running containers
+docker run --rm --gpus all nvidia/cuda:13.0.0-devel-ubuntu22.04 nvidia-smi -L
+```
+
+Prefer CDI unless you have a specific reason not to — it's what [`make smoke-gpu`](../testing-and-ci.md#cuda--gpu-verification-rigs) uses.
+
+For the Compose equivalents, see Docker's [GPU support in Compose](https://docs.docker.com/compose/how-tos/gpu-support/) and [GPU resource constraints](https://docs.docker.com/engine/containers/resource_constraints/). Note that Compose's documented `deploy.resources.reservations.devices` block with `driver: nvidia` goes through the **nvidia runtime**, so it needs the `daemon.json` path above. The CDI equivalent is a plain `devices:` entry — which is what [`docker-compose.yml`](../../docker-compose.yml) uses for the `gpu-verify` service:
+
+```yaml
+devices:
+  - nvidia.com/gpu=all
+```
+
+---
+
+## Step 6: Rehearse a toolkit upgrade inside the container
+
+The key idea, and the one thing worth remembering from this whole tutorial: **the container runtime injects the HOST driver, not a driver from the image.** So running `nvidia/cuda:<version>-devel-ubuntu22.04` with your GPU attached tests *your actual driver* against *that toolkit* — a faithful, disposable rehearsal of installing that toolkit on the host, without installing anything on the host. Use a `-devel` tag; `-base`/`-runtime` images don't ship `nvcc`. See the [image list on Docker Hub](https://hub.docker.com/r/nvidia/cuda).
+
+Start a shell in the target toolkit's image:
+
+```sh
+docker run --rm -it --device nvidia.com/gpu=all nvidia/cuda:13.0.0-devel-ubuntu22.04 bash
+```
+
+**1. What does the driver report, from inside the container?**
+
+```sh
+nvidia-smi --query-gpu=driver_version,name,compute_cap --format=csv,noheader
+```
+
+Measured on the real machine this tutorial was written against:
+
+```text
+580.173.02, NVIDIA GeForce RTX 3060 Ti, 8.6
+```
+
+**2. What toolkit is actually in this image?**
+
+```sh
+nvcc --version
+```
+
+```text
+Cuda compilation tools, release 13.0, V13.0.48
+```
+
+**3. Does this toolkit still target your GPU's architecture?** A newer toolkit dropping your architecture is a hard blocker, not a warning:
+
+```sh
+nvcc --list-gpu-arch | grep compute_86
+```
+
+If that prints nothing, stop — this toolkit cannot produce code for your GPU, full stop, regardless of anything else in this tutorial.
+
+**4. Compile and run something for your actual architecture** (`sm_86` for compute capability 8.6 — adjust to the `compute_cap` value from item 1 above):
+
+The probe **must contain an actual `__global__` kernel and launch it.** A program that only calls
+runtime-API functions compiles to a binary with no device code at all, which makes item 5's JIT check
+silently meaningless — see the warning there.
+
+```cpp
+// probe.cu
+#include <cstdio>
+
+__global__ void k(int* out) { *out = 42; }
+
+int main() {
+    int driver_api = 0, runtime_api = 0;
+    cudaDriverGetVersion(&driver_api);
+    cudaRuntimeGetVersion(&runtime_api);
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+    printf("device=%s sm=%d.%d driver_api=%d runtime_api=%d\n",
+           prop.name, prop.major, prop.minor, driver_api, runtime_api);
+
+    int* d;
+    if (cudaMalloc(&d, sizeof(int)) != cudaSuccess) { printf("MALLOC_FAIL\n"); return 3; }
+    k<<<1, 1>>>(d);
+    cudaError_t err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) { printf("LAUNCH_FAIL=%s\n", cudaGetErrorString(err)); return 4; }
+
+    int h = 0;
+    cudaMemcpy(&h, d, sizeof(int), cudaMemcpyDeviceToHost);
+    printf("kernel_result=%d %s\n", h, h == 42 ? "OK" : "BAD");
+    return h == 42 ? 0 : 5;
+}
+```
+
+```sh
+nvcc -arch=sm_86 -o probe probe.cu
+./probe
+```
+
+```text
+device=NVIDIA GeForce RTX 3060 Ti sm=8.6 driver_api=13000 runtime_api=13000
+kernel_result=42 OK
+```
+
+A prebuilt `cubin` loading and running confirms the basics. It does **not** yet prove minor-version compatibility — that's the next check.
+
+**5. The PTX JIT check — the sharpest test in this whole tutorial.** Build with `-arch=compute_86 -code=compute_86` instead of `sm_86`. That combination emits **only PTX**, no cubin at all, so there is nothing for the driver to load directly — it is forced to JIT-compile the PTX itself at launch time:
+
+```sh
+nvcc -arch=compute_86 -code=compute_86 -o probe_ptx probe.cu
+./probe_ptx
+```
+
+```text
+device=NVIDIA GeForce RTX 3060 Ti sm=8.6 driver_api=13000 runtime_api=13000
+kernel_result=42 OK
+```
+
+> **Confirm the test isn't hollow before you trust it.** This check only means something if the binary
+> actually contains PTX and no cubin. Verify with
+> [`cuobjdump`](https://docs.nvidia.com/cuda/cuda-binary-utilities/index.html):
+>
+> ```sh
+> cuobjdump --dump-ptx probe_ptx | grep -c '\.entry'   # expect >= 1  (PTX is present)
+> cuobjdump --dump-elf probe_ptx | grep -c 'elf code'  # expect 0     (no cubin to fall back on)
+> ```
+>
+> If the first number is `0` there is no device code in the binary at all, and the run below proves
+> nothing about JIT — it would pass even on a driver that could not JIT anything. That is exactly what
+> happens if your `probe.cu` has no `__global__` kernel, or has one that is never launched.
+
+This matters because **this is the exact mechanism CUDA minor-version compatibility relies on** — a driver from an earlier point release in the same major series is expected to JIT-compile PTX from a later toolkit successfully. If your driver is too old for the toolkit, this is the check that fails, even when item 4's prebuilt cubin ran fine (a cubin only proves the specific SM version it was built for still executes; it says nothing about whether the driver's PTX compiler understands newer toolkit output). If this step fails, treat it as authoritative: do not install that toolkit series against this driver.
+
+On the measured machine, every one of these checks passed, including PTX JIT — consistent with driver 580.173.02 clearing CUDA 13.0's minor-version-compatibility floor of 580 (Step 4).
+
+---
+
+## Step 7: Sanity-check apt package selection before you touch anything
+
+These are all traps that were hit for real while building the automated rigs — check for them before running an install or removal, not after.
+
+**`apt install cuda` pulls a driver, and can replace your working one.** The `cuda` metapackage depends on `cuda-drivers`. If you only want a toolkit:
+
+```sh
+sudo apt-get install -y cuda-toolkit-13-0     # exact series, no driver package
+```
+
+**Plain `cuda-toolkit` floats to the newest series** (13.3 as of this writing), which may need a driver newer than yours (Step 4). Pin the series explicitly as above.
+
+**Never run `apt-get remove --purge '^nvidia-.*'`.** It shows up in blog posts as a "clean slate" one-liner and it destroys your working driver along with everything else matching that pattern.
+
+**`cuda-keyring` pins NVIDIA's entire repo above Ubuntu's.** Installing it drops `/etc/apt/preferences.d/cuda-repository-pin-600`, at priority 600 — above Ubuntu's default 500. After that, `apt upgrade` prefers NVIDIA's driver builds over Ubuntu's unless you counter-pin. Check before assuming either way:
+
+```sh
+apt-cache policy nvidia-driver-580
+```
+
+**A naive counter-pin is wrong.** Pinning broad patterns like `nvidia-* libnvidia-*` back down blocks packages that have no Ubuntu equivalent at all — `nvidia-container-toolkit`, `libnvidia-container1`, `nvidia-fs`, `nvidia-gds` — while still *missing* `libxnvctrl0`, which NVIDIA ships under a name the naive pattern doesn't match. Pin specific driver-package name patterns instead (see the pin block in [`scripts/cuda-verify-config.sh`](../../scripts/cuda-verify-config.sh), Stage 1, for the exact patterns this repo verified), then confirm with a **negative control** — check the candidate both *without* and *with* the pin file, so you know the pin actually did something rather than the test passing vacuously either way:
+
+```sh
+apt-cache policy cuda-toolkit-13-0            # before adding your pin
+# ... write the pin file ...
+apt-cache policy cuda-toolkit-13-0            # after — candidate/priority should change
+apt-cache policy nvidia-container-toolkit      # must still resolve — this is what a broad pin breaks
+```
+
+If a broad pin broke it, `apt-cache policy` reports no candidate at all:
+
+```text
+nvidia-container-toolkit:
+  Installed: (none)
+  Candidate: (none)
+```
+
+and the install fails with:
+
+```text
+This may mean that the package is missing, has been obsoleted, or
+is only available from another source
+
+E: Package 'nvidia-container-toolkit' has no installation candidate
+```
+
+Note the failure mode is indistinguishable from "the package doesn't exist" unless you think to check
+your own pin files — which is what makes this one easy to misdiagnose. `apt-cache policy` is the
+faster diagnostic: a package present in the index but pinned out shows its versions with a negative
+priority, whereas a genuinely absent package shows no version table at all. See
+[`apt_preferences(5)`](https://manpages.debian.org/bookworm/apt/apt_preferences.5.en.html) for how
+priorities are resolved.
+
+**`apt purge '*cuda*'` also removes `cuda-keyring` itself** — taking NVIDIA's `sources.list` entry and its 600 pin with it. A hand-written pin file under `/etc/apt/preferences.d/` belongs to no package, so it survives a purge that wipes out everything package-owned.
+
+Other useful commands for checking before you commit to a change:
+
+```sh
+apt-cache madison cuda-toolkit-13-0     # every available version/repo for a package
+apt-get -s install cuda-toolkit-13-0    # simulate the install, read what it would pull
+apt-get -s upgrade                      # simulate a full upgrade
+update-alternatives --display cuda      # what the symlink currently resolves to
+dpkg -S /usr/local/cuda/bin/nvcc        # which package owns a given path
+dkms status                             # driver kernel modules currently built
+```
+
+**Removing the system toolkit does not break pip-installed PyTorch.** A `+cuXXX` PyTorch wheel resolves its own CUDA libraries from `site-packages/nvidia/*`, never from `/usr/local/cuda`:
+
+```sh
+ldd "$(python -c 'import torch, os; print(os.path.dirname(torch.__file__))')/lib/libtorch_cuda.so" \
+    | grep -E 'cublas|cudart'
+```
+
+The paths printed live under `.../site-packages/nvidia/...`, not `/usr/local/cuda`. Purging a system toolkit affects only things that *compile* CUDA code (like `nvcc` builds), not a pip-installed PyTorch that only *runs* it.
+
+---
+
+## When to use the automated rigs instead
+
+Once you understand what a check is actually asserting, prefer the rigs for day-to-day verification — they run the same logic against real NVIDIA packages, are faster to run than to hand-type, and don't require you to remember all of the above:
+
+```sh
+make smoke-cuda   # module verification against real apt packages, no GPU needed
+make smoke-gpu    # driver/toolkit rehearsal against your host's real driver, GPU required
+```
+
+Each Step above maps onto a stage in one of the two scripts, so they double as readable references:
+Steps 1–3 correspond to [`scripts/cuda-verify-config.sh`](../../scripts/cuda-verify-config.sh)
+(stages 0, 2–4, 7–8), Step 7's pin checks to its stage 1, and Steps 4–6 to
+[`scripts/cuda-verify-gpu.sh`](../../scripts/cuda-verify-gpu.sh).
+
+Come back to this tutorial when a rig fails and you need to isolate which check broke, or when you want to probe a scenario the rigs don't parameterize (a specific driver floor via `MIN_DRIVER`, a specific toolkit via `CUDA_IMAGE`/`CUDA_SERIES` — see [docs/testing-and-ci.md](../testing-and-ci.md#cuda--gpu-verification-rigs) for every override).
+
+Remember why these rigs exist at all: **CI never touches this code.** The GitHub Actions matrix in [`tests.yml`](../../.github/workflows/tests.yml) is macOS-only, and the `cuda` sheldon plugin is gated on `.chezmoi.os == "linux"` — so no CI job ever sources `home/shell/cuda/custom.zsh` or `posix-env.sh`. [`Dockerfile.cuda`](../../Dockerfile.cuda) and [`Dockerfile.gpu`](../../Dockerfile.gpu) are the only real coverage.
+
+> **Safety note:** [`scripts/cuda-verify-config.sh`](../../scripts/cuda-verify-config.sh) installs and purges real NVIDIA packages as part of its matrix. It refuses to run outside a container unless you set `FORCE=1` — don't set that on a machine you care about.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `nvidia-smi` not found inside the container | GPU wasn't actually attached to the container | Re-run with `--device nvidia.com/gpu=all` (CDI) or `--gpus all` (nvidia runtime); confirm the toolkit is installed on the host with `nvidia-ctk cdi list` |
+| `nvcc` not found | You used a `-base` or `-runtime` image tag | Use a `-devel` tag — only those ship the compiler |
+| `no CDI devices` / device not found | CDI spec missing or stale, or Docker < 25 | Re-run `sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml`; check `docker info \| grep -i -A1 cdi` for CDI support |
+| Fake-root probe gives a result that doesn't match this tutorial | Ran in a normal shell instead of `env -i ... zsh -f` | A normal shell inherits your real `PATH`/env and silently contaminates the result — always use `env -i` with an explicit `PATH` |
+| `E: Package 'nvidia-container-toolkit' has no installation candidate` after pinning | Your counter-pin used a too-broad pattern (`nvidia-*`/`libnvidia-*`) | Narrow the pin to actual driver-package name patterns; see Step 7 |
+| PTX JIT step fails, but the `sm_86`-built binary ran fine | Driver is below the toolkit's minor-version-compatibility floor | Don't install this toolkit against this driver — a passing cubin does not mean a passing PTX JIT; see Step 6 |
+
+---
+
+## Verify
+
+```sh
+# 1. The module resolves correctly against a disposable fake root -- no host changes
+ZMOD="$(chezmoi source-path)/shell/cuda/custom.zsh"
+root=$(mktemp -d) && mkdir -p "$root"/cuda-13.0/bin && ln -s "$root"/cuda-13.0 "$root"/cuda
+env -i PATH=/usr/bin:/bin ZSH_DOTFILES_CUDA_ROOT="$root" \
+    zsh -f -c "source '$ZMOD'; echo \$CUDA_HOME"
+# -> prints the fake symlink path
+
+# 2. LD_LIBRARY_PATH is unset, and libcudart still resolves on the real host
+echo "${LD_LIBRARY_PATH:-<unset>}"
+ldconfig -p | grep -c libcudart
+
+# 3. The container rehearsal passed every stage, including PTX JIT
+#    (rerun Step 6 by hand, or trust the automated rig once you've read this far)
+make smoke-gpu
+```
+
+If all three come back clean, you understand the module well enough to debug a rig failure, and you've rehearsed the specific toolkit change against your real driver without installing anything on the host yet.
+
+---
+
+## Next steps
+
+- **[docs/testing-and-ci.md](../testing-and-ci.md#cuda--gpu-verification-rigs)** — the full rig reference: every stage of `Dockerfile.cuda`/`Dockerfile.gpu`, and every environment-variable override
+- **[docs/shell-loading.md](../shell-loading.md)** — where the `cuda` module sits in the full 24-step plugin load order
+- **[Tutorial 05: Run Smoke Tests Locally](05-run-smoke-tests-locally.md)** — the same "reproduce CI before you push" philosophy, applied to the main smoke lane

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -17,6 +17,7 @@
 | 04 | [Switch Version Manager](04-switch-version-manager.md) | You've migrated the machine from `asdf` to `mise` (or back) |
 | 05 | [Run Smoke Tests Locally](05-run-smoke-tests-locally.md) | You can reproduce the CI matrix in Docker before pushing |
 | 06 | [Customize iTerm2](06-customize-iterm2.md) | Your iTerm2 profile changes are captured into the repo and re-applied on another machine |
+| 07 | [Verify CUDA Before Applying](07-verify-cuda-before-applying.md) | You can inspect your CUDA/driver state, prove the shell module resolves correctly, and rehearse a toolkit upgrade in a container before touching the host |
 
 If you're brand new here, start at **00** and work down — each tutorial after 01 stands alone, so feel free to skip to whichever one matches what you're trying to do today.
 
@@ -32,6 +33,7 @@ flowchart LR
     T01 --> T04["04 Switch Version Manager"]
     T01 --> T05["05 Run Smoke Tests Locally"]
     T01 --> T06["06 Customize iTerm2"]
+    T01 --> T07["07 Verify CUDA Before Applying"]
 ```
 
 ---

--- a/home/compat.bash.tmpl
+++ b/home/compat.bash.tmpl
@@ -3,10 +3,7 @@
 # chezmoi managed - ~/.bashrc
 # ---------------------------------------------------------
 export PATH="${HOME}/bin:${HOME}/.bin:${HOME}/.local/bin:$PATH"
-export PATH="/usr/local/cuda/bin:${PATH}"
-export PATH="/usr/local/cuda-11.8/bin${PATH:+:${PATH}}"
-export LD_LIBRARY_PATH="/usr/local/cuda-11.8/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-
+{{ include "shell/cuda/posix-env.sh" }}
 
 [ -f ~/.fzf.bash ] && . ~/.fzf.bash
 

--- a/home/compat.sh.tmpl
+++ b/home/compat.sh.tmpl
@@ -3,10 +3,7 @@
 # chezmoi managed - ~/.profile
 # ---------------------------------------------------------
 export PATH="${HOME}/bin:${HOME}/.bin:${HOME}/.local/bin:$PATH"
-export PATH=/usr/local/cuda/bin:${PATH}
-export PATH=/usr/local/cuda-11.8/bin${PATH:+:${PATH}}
-export LD_LIBRARY_PATH=/usr/local/cuda-11.8/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-
+{{ include "shell/cuda/posix-env.sh" }}
 if [ -n "$ZSH_VERSION" ]; then
     [ -f ~/.fzf.zsh ] && . ~/.fzf.zsh
 elif [ -n "$BASH_VERSION" ]; then

--- a/home/shell/cuda/custom.zsh
+++ b/home/shell/cuda/custom.zsh
@@ -1,3 +1,53 @@
-export PATH="/usr/local/cuda/bin:${PATH}"
-export PATH="/usr/local/cuda-11.8/bin${PATH:+:${PATH}}"
-export LD_LIBRARY_PATH="/usr/local/cuda-11.8/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+# CUDA toolkit environment.
+#
+# Loaded immediately (not deferred) by [plugins.cuda], so it blocks the first
+# prompt: zsh builtins and globbing only, no subprocesses.
+#
+# Version-agnostic on purpose. apt installs and purges toolkits under /usr/local
+# without telling this file; the previous version pinned cuda-11.8 and went stale.
+#   1. Prefer ${root}/cuda -- the update-alternatives-managed symlink.
+#   2. Else the highest-numbered ${root}/cuda-<major>.<minor> still on disk.
+#   3. Else do nothing at all.
+#
+# LD_LIBRARY_PATH is deliberately NOT set. ${root}/cuda-X/lib64 is a symlink to
+# targets/x86_64-linux/lib, which the .deb packages already register via
+# /etc/ld.so.conf.d/000_cuda.conf. Since LD_LIBRARY_PATH outranks the ldconfig
+# cache, setting it only creates a way for a stale entry to shadow the correct
+# libraries.
+#
+# ZSH_DOTFILES_CUDA_ROOT overrides the search prefix for testing only.
+
+() {
+    emulate -L zsh
+
+    local root="${ZSH_DOTFILES_CUDA_ROOT:-/usr/local}"
+    local cuda_home="" candidate
+    local -a candidates
+
+    if [[ -d "${root}/cuda/bin" ]]; then
+        # -d follows the symlink, so a dangling ${root}/cuda fails this test.
+        cuda_home="${root}/cuda"
+    else
+        # (N-/) silent when nothing matches; dirs and symlinks-to-dirs only.
+        # (On)  reverse numeric sort, so 13.0 beats 9.0.
+        # The <major>.<minor> shape skips the cuda-11 / cuda-12 alternatives
+        # aliases, which are pointers to toolkits rather than toolkits.
+        candidates=( ${root}/cuda-[0-9]*.[0-9]*(N-/) )
+        for candidate in ${(On)candidates}; do
+            [[ -d "${candidate}/bin" ]] && { cuda_home="$candidate"; break; }
+        done
+    fi
+
+    [[ -n "$cuda_home" ]] || return 0
+
+    export CUDA_HOME="$cuda_home"
+    export CUDA_PATH="$cuda_home"   # CMake's FindCUDAToolkit looks for CUDA_PATH
+
+    # Containment-guarded so a re-source cannot grow PATH. Preferred over
+    # `typeset -U path`, which would dedupe PATH session-wide for every module
+    # sheldon loads after this one.
+    case ":${PATH}:" in
+        *":${cuda_home}/bin:"*) ;;
+        *) export PATH="${cuda_home}/bin:${PATH}" ;;
+    esac
+}

--- a/home/shell/cuda/posix-env.sh
+++ b/home/shell/cuda/posix-env.sh
@@ -1,0 +1,22 @@
+# CUDA toolkit environment (POSIX; sourced by ~/.profile via /bin/sh and by
+# ~/.bashrc). Inlined into home/compat.sh.tmpl and home/compat.bash.tmpl at
+# chezmoi render time via the include function -- edit here, not there.
+#
+# Unlike the zsh module (home/shell/cuda/custom.zsh) this trusts only the
+# update-alternatives-managed ${root}/cuda symlink, with no
+# highest-version-on-disk fallback: POSIX sh cannot version-sort without a
+# subprocess, and a lexical "last match" would pick cuda-9.0 over cuda-13.0.
+# If the symlink is broken, sh/bash sessions get no CUDA env -- the right
+# degradation for shells nobody does CUDA work in here.
+#
+# LD_LIBRARY_PATH intentionally not set; see custom.zsh for why.
+if [ -d "${ZSH_DOTFILES_CUDA_ROOT:-/usr/local}/cuda/bin" ]; then
+    CUDA_HOME="${ZSH_DOTFILES_CUDA_ROOT:-/usr/local}/cuda"
+    CUDA_PATH="${CUDA_HOME}"
+    export CUDA_HOME CUDA_PATH
+
+    case ":${PATH}:" in
+        *":${CUDA_HOME}/bin:"*) ;;
+        *) PATH="${CUDA_HOME}/bin${PATH:+:${PATH}}"; export PATH ;;
+    esac
+fi

--- a/scripts/backup-dotfiles.py
+++ b/scripts/backup-dotfiles.py
@@ -55,14 +55,22 @@ err_console = Console(stderr=True)
 ABS_PREFIX = "_abs"
 
 # Fallback target list, used only when `chezmoi managed` is unavailable. Mirrors
-# the chezmoi source tree (home/dot_*, home/dot_sheldon, home/private_dot_config,
-# home/private_dot_bin) as of this writing.
+# the chezmoi source tree (home/dot_*, home/compat.*, home/dot_sheldon,
+# home/private_dot_config, home/private_dot_bin) as of this writing.
+#
+# NOTE: not every managed target is a dotfile. `home/compat.sh.tmpl` and
+# `home/compat.bash.tmpl` render to ~/compat.sh and ~/compat.bash, which are
+# sourced by ~/.profile and ~/.bashrc respectively. They are the only entries here
+# without a leading dot, which is precisely why they were missed originally --
+# don't drop them when refreshing this list.
 STATIC_TARGETS: tuple[str, ...] = (
     "~/.zshrc",
     "~/.zshrc.local",
     "~/.zprofile",
     "~/.bashrc",
     "~/.profile",
+    "~/compat.sh",
+    "~/compat.bash",
     "~/.gitconfig",
     "~/.gitignore_global",
     "~/.agignore",

--- a/scripts/cuda-verify-config.sh
+++ b/scripts/cuda-verify-config.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Verify the CUDA shell modules against REAL NVIDIA apt packages.
+#
+# Exercises home/shell/cuda/custom.zsh and home/shell/cuda/posix-env.sh against
+# real NVIDIA packages, real update-alternatives, and real /etc/ld.so.conf.d.
+# Nothing in CI covers this: CI runs on macOS only and the cuda sheldon plugin is
+# Linux-gated, so this script is the actual gate for that code.
+#
+# No GPU required - the modules only inspect the filesystem. For driver/runtime
+# compatibility checks, use scripts/cuda-verify-gpu.sh instead.
+#
+# Installs and purges real CUDA packages, so it refuses to run outside a
+# container unless FORCE=1.
+#
+# Usage:
+#   ./scripts/cuda-verify-config.sh                  # full matrix
+#   ./scripts/cuda-verify-config.sh --help
+#   DOTFILES_DIR=/mnt/x ./scripts/cuda-verify-config.sh
+#   CUDA_SERIES=12-1 ./scripts/cuda-verify-config.sh
+#
+# Not `set -e`: every check should run so the result is a full matrix. apt steps
+# are gated by must() instead, because a silently-failed install would make a
+# later guard check pass vacuously.
+set -uo pipefail
+
+case "${1:-}" in
+    -h | --help)
+        sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+esac
+
+DOTFILES_DIR="${DOTFILES_DIR:-/tmp/dotfiles}"
+CUDA_SERIES="${CUDA_SERIES:-13-0}"
+ZMOD="${DOTFILES_DIR}/home/shell/cuda/custom.zsh"
+PMOD="${DOTFILES_DIR}/home/shell/cuda/posix-env.sh"
+CLEANPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+BLUE='\033[34m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log_pass() {
+    echo -e "  ${GREEN}PASS${RESET} $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+log_fail() {
+    echo -e "  ${RED}FAIL${RESET} $1"
+    if [ -n "${2:-}" ]; then
+        echo "       $2"
+    fi
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+log_note() { echo -e "  ${YELLOW}note${RESET} $1"; }
+log_section() { echo -e "\n${BLUE}=== $1 ===${RESET}"; }
+
+expect() {
+    if [ "$2" = "$3" ]; then
+        log_pass "$1"
+    else
+        log_fail "$1" "got [$2] want [$3]"
+    fi
+}
+
+must() {
+    if "$@" > /tmp/cuda-verify-apt.log 2>&1; then
+        log_pass "apt: $*"
+    else
+        log_fail "apt: $*" "$(tail -4 /tmp/cuda-verify-apt.log)"
+        echo -e "\n${RED}Aborting: later guard checks would pass vacuously.${RESET}"
+        exit 1
+    fi
+}
+
+# Space-separated list of existing paths matching a glob, without parsing ls.
+list_paths() {
+    local p
+    local -a found=()
+    for p in "$@"; do
+        if [ -e "$p" ]; then
+            found+=("$p")
+        fi
+    done
+    if [ ${#found[@]} -eq 0 ]; then
+        echo "(none)"
+    else
+        echo "${found[*]}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Guard rails
+# ---------------------------------------------------------------------------
+in_container() {
+    [ -f /.dockerenv ] && return 0
+    grep -qaE 'docker|containerd|lxc' /proc/1/cgroup 2>/dev/null && return 0
+    return 1
+}
+
+if [ "${FORCE:-0}" != "1" ] && ! in_container; then
+    echo -e "${RED}Refusing to run outside a container.${RESET}" >&2
+    echo "This script installs and purges real CUDA packages." >&2
+    echo "Use 'make smoke-cuda', or set FORCE=1 if you genuinely mean this." >&2
+    exit 2
+fi
+
+for f in "$ZMOD" "$PMOD"; do
+    if [ ! -r "$f" ]; then
+        echo -e "${RED}Missing ${f}${RESET} - set DOTFILES_DIR?" >&2
+        exit 2
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Probes. The zsh and POSIX programs live in files rather than inline quoted
+# strings so the shell under test does the expansion, not this script.
+# ---------------------------------------------------------------------------
+PROBE_DIR="$(mktemp -d)"
+trap 'rm -rf "$PROBE_DIR"' EXIT
+
+cat > "${PROBE_DIR}/probe.zsh" << 'PROBE_ZSH'
+source "$ZMOD"
+source "$ZMOD"   # twice: proves PATH cannot grow on re-source
+cuda_entries=${#${(M)${(s.:.)PATH}:#*cuda*}}
+print -r -- "${CUDA_HOME:-NONE}|${cuda_entries}|${LD_LIBRARY_PATH:-NONE}"
+PROBE_ZSH
+
+cat > "${PROBE_DIR}/probe.sh" << 'PROBE_SH'
+. "$PMOD"
+. "$PMOD"
+cuda_entries=$(printf %s "$PATH" | tr ":" "\n" | grep -c cuda)
+printf "%s|%s|%s\n" "${CUDA_HOME:-NONE}" "$cuda_entries" "${LD_LIBRARY_PATH:-NONE}"
+PROBE_SH
+
+zprobe() {
+    env -i PATH="$CLEANPATH" ZMOD="$ZMOD" zsh -f "${PROBE_DIR}/probe.zsh"
+}
+sprobe() {
+    env -i PATH="$CLEANPATH" PMOD="$PMOD" "$1" "${PROBE_DIR}/probe.sh"
+}
+
+echo -e "${BLUE}CUDA shell-module verification${RESET}"
+echo "  dotfiles : ${DOTFILES_DIR}"
+echo "  series   : ${CUDA_SERIES}"
+
+# ---------------------------------------------------------------------------
+log_section "Stage 0 - nothing installed (the post-purge steady state)"
+expect "zsh no-op" "$(zprobe)" "NONE|0|NONE"
+expect "dash no-op" "$(sprobe dash)" "NONE|0|NONE"
+expect "bash no-op" "$(sprobe bash)" "NONE|0|NONE"
+rc_out=$(env -i ZMOD="$ZMOD" zsh -f "${PROBE_DIR}/probe.zsh" > /dev/null 2>&1; echo "rc=$?")
+expect "zsh exits 0 with no diagnostics" "$rc_out" "rc=0"
+
+# ---------------------------------------------------------------------------
+log_section "Stage 1 - apt pin must beat NVIDIA's priority-600 repo pin"
+if [ -r /etc/apt/preferences.d/cuda-repository-pin-600 ]; then
+    log_note "cuda-keyring ships a 600 pin for 'release l=NVIDIA CUDA', above Ubuntu's 500"
+    before=$(apt-cache policy nvidia-driver-580 2>/dev/null | awk '/Candidate:/{print $2}')
+    cat > /etc/apt/preferences.d/99-nvidia-driver-from-ubuntu << 'PIN'
+Package: nvidia-driver-* nvidia-dkms-* nvidia-kernel-common-* nvidia-kernel-source-* nvidia-utils-* nvidia-compute-utils-* nvidia-firmware-* xserver-xorg-video-nvidia-*
+Pin: release o=NVIDIA
+Pin-Priority: -1
+
+Package: libnvidia-cfg1-* libnvidia-common-* libnvidia-compute-* libnvidia-decode-* libnvidia-encode-* libnvidia-extra-* libnvidia-fbc1-* libnvidia-gl-* libxnvctrl*
+Pin: release o=NVIDIA
+Pin-Priority: -1
+PIN
+    after=$(apt-cache policy nvidia-driver-580 2>/dev/null | awk '/Candidate:/{print $2}')
+    echo "  candidate without pin: ${before}"
+    echo "  candidate with    pin: ${after}"
+
+    case "$before" in
+        *-1ubuntu1) log_pass "negative control: NVIDIA build wins without our pin (${before})" ;;
+        *) log_fail "negative control" "expected an NVIDIA '-1ubuntu1' build, got '${before}'" ;;
+    esac
+    case "$after" in
+        *ubuntu0.*) log_pass "pin holds: Ubuntu-archive build selected (${after})" ;;
+        *) log_fail "pin did not hold" "got '${after}'" ;;
+    esac
+
+    # The narrow patterns must not collaterally block non-driver NVIDIA packages.
+    # A naive 'nvidia-*' pattern blocks this one, which is how the bug was found.
+    toolkit_cand=$(apt-cache policy nvidia-container-toolkit 2>/dev/null | awk '/Candidate:/{print $2}')
+    if [ -n "$toolkit_cand" ] && [ "$toolkit_cand" != "(none)" ]; then
+        log_pass "pin does not block nvidia-container-toolkit (${toolkit_cand})"
+    else
+        log_fail "pin is too broad" "nvidia-container-toolkit candidate is '${toolkit_cand:-empty}'"
+    fi
+
+    if apt-get install -s "cuda-toolkit-${CUDA_SERIES}" 2>/dev/null |
+        grep -qE '^Inst (nvidia-driver|libnvidia-(cfg1|common|compute|decode|encode|extra|fbc1|gl)|xserver-xorg-video-nvidia)'; then
+        log_fail "toolkit must pull no driver packages" "see: apt-get install -s cuda-toolkit-${CUDA_SERIES}"
+    else
+        log_pass "cuda-toolkit-${CUDA_SERIES} pulls zero driver packages"
+    fi
+else
+    log_note "no NVIDIA apt repo in this image - skipping pin checks"
+fi
+
+# ---------------------------------------------------------------------------
+log_section "Stage 2 - real alternatives for two toolkits that have no bin/"
+# config-common's postinst runs update-alternatives against these paths, so they
+# must exist first; on a real host the content packages create them.
+mkdir -p /usr/local/cuda-11.8 /usr/local/cuda-12.1
+must apt-get install -y --no-install-recommends \
+    cuda-toolkit-11-8-config-common cuda-toolkit-12-1-config-common
+update-alternatives --display cuda 2>&1 | sed 's/^/    /'
+echo "  /usr/local/cuda -> $(readlink -f /usr/local/cuda 2>/dev/null || echo '(absent)')"
+expect "zsh rejects toolkits lacking bin/" "$(zprobe)" "NONE|0|NONE"
+expect "dash rejects them too" "$(sprobe dash)" "NONE|0|NONE"
+
+# ---------------------------------------------------------------------------
+log_section "Stage 3 - install a real nvcc for series ${CUDA_SERIES}"
+must apt-get install -y --no-install-recommends "cuda-nvcc-${CUDA_SERIES}"
+update-alternatives --display cuda 2>&1 | sed 's/^/    /'
+REAL_TOOLKIT="$(readlink -f /usr/local/cuda)"
+echo "  resolved toolkit: ${REAL_TOOLKIT}"
+expect "zsh prefers the alternatives-managed symlink" "$(zprobe)" "/usr/local/cuda|1|NONE"
+
+cat > "${PROBE_DIR}/nvcc.zsh" << 'PROBE_NVCC'
+source "$ZMOD"
+nvcc --version 2>/dev/null | grep -o 'release [0-9.]*'
+PROBE_NVCC
+nvcc_ver=$(env -i PATH=/usr/bin:/bin ZMOD="$ZMOD" zsh -f "${PROBE_DIR}/nvcc.zsh")
+if [ -n "$nvcc_ver" ]; then
+    log_pass "nvcc reachable via the module's PATH (${nvcc_ver})"
+else
+    log_fail "nvcc not reachable via the module's PATH"
+fi
+
+# ---------------------------------------------------------------------------
+log_section "Stage 3b - numeric ordering against real directories"
+# Force the glob fallback with 9.0 present: a lexical sort ranks it above 13.0.
+mv /usr/local/cuda /tmp/cuda-symlink-backup
+mkdir -p /usr/local/cuda-9.0/bin
+cp "${REAL_TOOLKIT}/bin/nvcc" /usr/local/cuda-9.0/bin/nvcc
+echo "  candidates: $(list_paths /usr/local/cuda-*)"
+expect "picks the highest real toolkit, not 9.0" "$(zprobe)" "${REAL_TOOLKIT}|1|NONE"
+# Remove the fixture right away: apt purge will not clean up hand-made files, and
+# leaving it would silently invalidate Stage 8's expectation.
+rm -rf /usr/local/cuda-9.0
+
+# ---------------------------------------------------------------------------
+log_section "Stage 4 - cuda-NN major-version aliases must be ignored"
+echo "  aliases present: $(list_paths /usr/local/cuda-[0-9] /usr/local/cuda-[0-9][0-9])"
+alias_probe=$(zprobe)
+case "$alias_probe" in
+    /usr/local/cuda-[0-9]\|* | /usr/local/cuda-[0-9][0-9]\|*)
+        log_fail "a major-version alias leaked into CUDA_HOME" "got [${alias_probe}]"
+        ;;
+    *)
+        log_pass "major-version aliases excluded by the <major>.<minor> glob shape"
+        ;;
+esac
+mv /tmp/cuda-symlink-backup /usr/local/cuda
+
+# ---------------------------------------------------------------------------
+log_section "Stage 5 - libraries resolve with LD_LIBRARY_PATH unset"
+must apt-get install -y --no-install-recommends "cuda-cudart-${CUDA_SERIES}"
+ldconfig
+cudart_entries=$(ldconfig -p | grep -cE 'libcudart')
+if [ "$cudart_entries" -gt 0 ]; then
+    log_pass "ldconfig finds libcudart without LD_LIBRARY_PATH (${cudart_entries} entries)"
+else
+    log_fail "ldconfig found no libcudart" "dropping LD_LIBRARY_PATH would be unsafe"
+fi
+grep -rh . /etc/ld.so.conf.d/*cuda* 2>/dev/null | sed 's/^/    /'
+
+# ---------------------------------------------------------------------------
+log_section "Stage 6 - purge the two stale toolkits"
+must apt-get purge -y cuda-toolkit-11-8-config-common cuda-toolkit-12-1-config-common
+update-alternatives --display cuda 2>&1 | sed 's/^/    /'
+expect "still resolves the remaining toolkit" "$(zprobe)" "/usr/local/cuda|1|NONE"
+
+# ---------------------------------------------------------------------------
+log_section "Stage 7 - dangling symlink (the mid-purge transient window)"
+ln -sfn /usr/local/cuda-does-not-exist /usr/local/cuda
+echo "  /usr/local/cuda -> $(readlink /usr/local/cuda) (target absent)"
+expect "dangling symlink rejected, falls back to a real toolkit" "$(zprobe)" "${REAL_TOOLKIT}|1|NONE"
+expect "POSIX snippet no-ops on a dangling symlink" "$(sprobe dash)" "NONE|0|NONE"
+
+# ---------------------------------------------------------------------------
+log_section "Stage 8 - purge everything CUDA"
+apt-get purge -y '*cuda*' > /dev/null 2>&1
+echo "  gutted dirs left behind: $(list_paths /usr/local/cuda*)"
+log_note "purging '*cuda*' also removes cuda-keyring, taking NVIDIA's repo and 600 pin with it"
+log_note "our own pin file belongs to no package, so it survives:"
+find /etc/apt/preferences.d -maxdepth 1 -type f -printf '    %f\n' 2>/dev/null
+expect "zsh no-op with gutted dirs present" "$(zprobe)" "NONE|0|NONE"
+expect "dash no-op with gutted dirs present" "$(sprobe dash)" "NONE|0|NONE"
+
+# ---------------------------------------------------------------------------
+log_section "RESULT"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+    echo -e "  ${GREEN}${PASS_COUNT} passed, ${FAIL_COUNT} failed${RESET}"
+else
+    echo -e "  ${RED}${PASS_COUNT} passed, ${FAIL_COUNT} failed${RESET}"
+fi
+[ "$FAIL_COUNT" -eq 0 ]

--- a/scripts/cuda-verify-gpu.sh
+++ b/scripts/cuda-verify-gpu.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Verify a CUDA toolkit actually works against the HOST's installed driver.
+#
+# Runs inside Dockerfile.gpu with the GPU exposed. The container runtime injects
+# the host driver, so this is a faithful rehearsal of a toolkit upgrade: point
+# CUDA_IMAGE at the toolkit you plan to install, run this, and you learn whether
+# your driver can run its output BEFORE touching the host.
+#
+# The PTX JIT stage is the sharpest check. CUDA minor-version compatibility works
+# by the driver JIT-compiling the toolkit's PTX at load time, so a driver that is
+# too old fails there even when a prebuilt cubin happens to load fine.
+#
+# Requires nvidia-container-toolkit on the host and the GPU passed in with either
+# --device nvidia.com/gpu=all (CDI) or --gpus all (nvidia runtime).
+#
+# Usage:
+#   ./scripts/cuda-verify-gpu.sh
+#   ./scripts/cuda-verify-gpu.sh --help
+#   MIN_DRIVER=580.126.20 ./scripts/cuda-verify-gpu.sh   # assert a documented floor
+#
+set -uo pipefail
+
+case "${1:-}" in
+    -h | --help)
+        sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+        exit 0
+        ;;
+esac
+
+BLUE='\033[34m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+RED='\033[31m'
+RESET='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log_pass() {
+    echo -e "  ${GREEN}PASS${RESET} $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+log_fail() {
+    echo -e "  ${RED}FAIL${RESET} $1"
+    if [ -n "${2:-}" ]; then
+        echo "       $2"
+    fi
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+log_note() { echo -e "  ${YELLOW}note${RESET} $1"; }
+log_section() { echo -e "\n${BLUE}=== $1 ===${RESET}"; }
+
+# Indent piped input so probe output is visually nested under its section.
+indent() { sed 's/^/    /'; }
+
+# ---------------------------------------------------------------------------
+# Guard rails - fail with an actionable message, not a confusing stack of errors
+# ---------------------------------------------------------------------------
+if ! command -v nvidia-smi > /dev/null 2>&1; then
+    echo -e "${RED}nvidia-smi not found inside the container.${RESET}" >&2
+    echo "The GPU was not exposed. Use one of:" >&2
+    echo "  docker run --rm --device nvidia.com/gpu=all ...   # CDI" >&2
+    echo "  docker run --rm --gpus all ...                    # nvidia runtime" >&2
+    exit 2
+fi
+if ! nvidia-smi -L > /dev/null 2>&1; then
+    echo -e "${RED}nvidia-smi present but no GPU visible.${RESET}" >&2
+    echo "Is nvidia-container-toolkit installed on the host?" >&2
+    exit 2
+fi
+if ! command -v nvcc > /dev/null 2>&1; then
+    echo -e "${RED}nvcc not found.${RESET} Use a -devel image, not -base or -runtime." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+log_section "Host driver, as seen from inside the container"
+nvidia-smi --query-gpu=driver_version,name,compute_cap,memory.total \
+    --format=csv,noheader | indent
+DRIVER=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1 | tr -d '[:space:]')
+CAP=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '[:space:]. ')
+log_pass "GPU visible; host driver ${DRIVER}, compute capability ${CAP}"
+
+if [ -n "${MIN_DRIVER:-}" ]; then
+    lowest=$(printf '%s\n%s\n' "$MIN_DRIVER" "$DRIVER" | sort -V | head -1)
+    if [ "$lowest" = "$MIN_DRIVER" ]; then
+        log_pass "driver ${DRIVER} >= documented minimum ${MIN_DRIVER}"
+    else
+        log_fail "driver too old" "${DRIVER} < required ${MIN_DRIVER}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+log_section "Toolkit in this image"
+nvcc --version | tail -2 | indent
+TOOLKIT=$(nvcc --version | grep -o 'release [0-9.]*' | awk '{print $2}')
+if [ -n "$TOOLKIT" ]; then
+    log_pass "toolkit is CUDA ${TOOLKIT}"
+else
+    log_fail "could not determine the toolkit version"
+fi
+
+# ---------------------------------------------------------------------------
+log_section "Is this GPU's architecture still a supported target?"
+if nvcc --list-gpu-arch 2>/dev/null | grep -qx "compute_${CAP}"; then
+    log_pass "sm_${CAP} is in CUDA ${TOOLKIT}'s target list"
+else
+    log_fail "sm_${CAP} is unsupported by CUDA ${TOOLKIT}" \
+        "targets: $(nvcc --list-gpu-arch 2>/dev/null | tr '\n' ' ')"
+    log_note "a toolkit dropping your architecture is a hard blocker, not a warning"
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "${WORK}/probe.cu" << 'PROBE_CU'
+#include <cstdio>
+
+__global__ void addk(const float* a, const float* b, float* c, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) c[i] = a[i] + b[i];
+}
+
+int main() {
+    int driver_api = 0, runtime_api = 0;
+    cudaDriverGetVersion(&driver_api);
+    cudaRuntimeGetVersion(&runtime_api);
+    printf("driver_api=%d runtime_api=%d\n", driver_api, runtime_api);
+    if (driver_api < runtime_api) {
+        printf("WARN driver API is older than the runtime API\n");
+    }
+
+    cudaDeviceProp prop{};
+    if (cudaGetDeviceProperties(&prop, 0) != cudaSuccess) {
+        printf("PROPS_FAIL\n");
+        return 2;
+    }
+    printf("device=%s sm=%d.%d\n", prop.name, prop.major, prop.minor);
+
+    const int n = 1 << 20;
+    float* ha = (float*)malloc(n * sizeof(float));
+    float* hb = (float*)malloc(n * sizeof(float));
+    float* hc = (float*)malloc(n * sizeof(float));
+    for (int i = 0; i < n; i++) { ha[i] = 1.5f; hb[i] = 2.25f; }
+
+    float *da, *db, *dc;
+    if (cudaMalloc(&da, n * sizeof(float)) != cudaSuccess) {
+        printf("MALLOC_FAIL\n");
+        return 3;
+    }
+    cudaMalloc(&db, n * sizeof(float));
+    cudaMalloc(&dc, n * sizeof(float));
+    cudaMemcpy(da, ha, n * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(db, hb, n * sizeof(float), cudaMemcpyHostToDevice);
+
+    addk<<<(n + 255) / 256, 256>>>(da, db, dc, n);
+    cudaError_t err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+        printf("KERNEL_FAIL=%s\n", cudaGetErrorString(err));
+        return 4;
+    }
+
+    cudaMemcpy(hc, dc, n * sizeof(float), cudaMemcpyDeviceToHost);
+    int wrong = 0;
+    for (int i = 0; i < n; i++) {
+        if (hc[i] < 3.74f || hc[i] > 3.76f) wrong++;
+    }
+    printf("mismatches=%d\n", wrong);
+    printf("%s\n", wrong == 0 ? "COMPUTE_OK" : "COMPUTE_BAD");
+    return wrong == 0 ? 0 : 5;
+}
+PROBE_CU
+
+# ---------------------------------------------------------------------------
+log_section "Build a real cubin for sm_${CAP} and execute it on driver ${DRIVER}"
+if nvcc "-arch=sm_${CAP}" -o "${WORK}/probe" "${WORK}/probe.cu" 2> "${WORK}/nvcc.err"; then
+    log_pass "nvcc -arch=sm_${CAP} compiled and linked"
+
+    cubin_out=$("${WORK}/probe" 2>&1)
+    cubin_rc=$?
+    printf '%s\n' "$cubin_out" | indent
+
+    if [ "$cubin_rc" -eq 0 ]; then
+        log_pass "CUDA ${TOOLKIT} binary executed on driver ${DRIVER} (exit 0)"
+    else
+        log_fail "execution failed" "exit ${cubin_rc}"
+    fi
+
+    if echo "$cubin_out" | grep -q COMPUTE_OK; then
+        log_pass "results numerically correct (1M-element vector add)"
+    else
+        log_fail "results incorrect or kernel did not run"
+    fi
+
+    driver_api=$(echo "$cubin_out" | sed -n 's/.*driver_api=\([0-9]*\).*/\1/p' | head -1)
+    runtime_api=$(echo "$cubin_out" | sed -n 's/.*runtime_api=\([0-9]*\).*/\1/p' | head -1)
+    if [ -n "$driver_api" ]; then
+        log_note "driver exposes CUDA driver API ${driver_api}; toolkit runtime API is ${runtime_api}"
+    fi
+else
+    log_fail "compile failed" "$(tail -3 "${WORK}/nvcc.err")"
+fi
+
+# ---------------------------------------------------------------------------
+log_section "PTX JIT: no cubin, so the driver must compile the PTX itself"
+log_note "this is the mechanism CUDA minor-version compatibility relies on"
+if nvcc "-arch=compute_${CAP}" "-code=compute_${CAP}" \
+    -o "${WORK}/probe_ptx" "${WORK}/probe.cu" 2> "${WORK}/ptx.err"; then
+    ptx_out=$("${WORK}/probe_ptx" 2>&1)
+    ptx_rc=$?
+    printf '%s\n' "$ptx_out" | indent
+    if [ "$ptx_rc" -eq 0 ]; then
+        log_pass "driver ${DRIVER} JIT-compiled CUDA ${TOOLKIT} PTX successfully"
+    else
+        log_fail "PTX JIT failed" "exit ${ptx_rc} - driver ${DRIVER} is too old for toolkit ${TOOLKIT}"
+    fi
+else
+    log_fail "PTX build failed" "$(tail -3 "${WORK}/ptx.err")"
+fi
+
+# ---------------------------------------------------------------------------
+log_section "RESULT"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+    echo -e "  ${GREEN}${PASS_COUNT} passed, ${FAIL_COUNT} failed${RESET}"
+    echo "  Toolkit CUDA ${TOOLKIT} is safe to install against driver ${DRIVER}."
+else
+    echo -e "  ${RED}${PASS_COUNT} passed, ${FAIL_COUNT} failed${RESET}"
+    echo "  Do NOT install toolkit CUDA ${TOOLKIT} against driver ${DRIVER} until this is green."
+fi
+[ "$FAIL_COUNT" -eq 0 ]

--- a/test_scripts_backup_dotfiles.py
+++ b/test_scripts_backup_dotfiles.py
@@ -175,6 +175,21 @@ def test_discover_targets_static_fallback(
     assert len(paths) == len(mod.STATIC_TARGETS)
 
 
+def test_static_fallback_includes_non_dotfile_targets(
+    mod: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """~/compat.sh and ~/compat.bash are managed but have no leading dot.
+
+    They render from home/compat.sh.tmpl and home/compat.bash.tmpl and are sourced
+    by ~/.profile and ~/.bashrc. Being the only non-dot entries, they were omitted
+    from the original static list; this guards the regression.
+    """
+    monkeypatch.setattr(mod, "_run_chezmoi", lambda args: None)
+    paths, _ = mod.discover_targets()
+    for target in ("~/compat.sh", "~/compat.bash"):
+        assert Path(target).expanduser() in paths, f"{target} missing from static list"
+
+
 # --------------------------------------------------------------------------- #
 # do_backup
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
The CUDA shell config hardcoded `cuda-11.8` in three places with no existence guards:
`home/shell/cuda/custom.zsh`, `home/compat.bash.tmpl:6-8`, and `home/compat.sh.tmpl:6-8`.

On `boss-deeplearning` the two `PATH` lines actively disagreed with each other: `PATH` resolved
`nvcc` to **11.8**, while `update-alternatives` pointed `/usr/local/cuda` at **12.1** (priority 121
vs 118). The config was one `apt` operation away from leaving dangling `PATH` entries.

This makes the config correct before, during and after a toolkit removal or reinstall: it detects
what is on disk, prefers the `update-alternatives`-managed symlink, falls back to the newest
`cuda-<major>.<minor>` present, and does nothing at all when no toolkit exists. `CUDA_HOME` /
`CUDA_PATH` are now set (neither existed anywhere in the repo before). Exactly one `PATH` entry,
containment-guarded against re-sourcing.

### `LD_LIBRARY_PATH` is now removed, not just un-hardcoded

`/usr/local/cuda-X/lib64` is a symlink to `targets/x86_64-linux/lib`, which the `.deb` packages
already register via `/etc/ld.so.conf.d/000_cuda.conf` — `ldconfig -p` resolves 20 CUDA libraries
with `LD_LIBRARY_PATH` unset. NVIDIA's install guide states the variable is required for **runfile**
installs only. Since `LD_LIBRARY_PATH` outranks the `ldconfig` cache, the stale value could shadow
correct libraries. Removing it is a bug fix.

### Three-way duplication collapses to two implementations, one copy each

The zsh module, plus a POSIX snippet inlined into both compat templates via `include` — the pattern
already used for `shell/init.zsh` in `dot_zshrc.tmpl`. The POSIX variant deliberately has no
highest-version fallback, since `sh` cannot version-sort without a subprocess and a lexical "last
match" would pick `cuda-9.0` over `cuda-13.0`.

### Verification

CI cannot cover this — `tests.yml` runs only on macOS and both blocks are Linux-gated. So it was
verified locally against throwaway prefixes via the new `ZSH_DOTFILES_CUDA_ROOT` override, sourcing
twice each to prove idempotency:

| State | Result |
|---|---|
| 3 toolkits + valid symlink + `cuda-11`/`cuda-12` aliases | prefers symlink; aliases correctly ignored |
| Dangling symlink + `cuda-9.0` + `cuda-11.8` + `cuda-13.0` | picks `13.0` — numeric sort, not lexical |
| Exactly one toolkit, no symlink | picks it |
| No toolkit at all | `CUDA_HOME` unset, `PATH` untouched, `rc=0`, no output |
| Toolkit dir present but `bin/` gone (mid-purge) | rejected, falls back |
| Sourced 3x | exactly one `PATH` entry |

Also: `zsh -n` clean, `shellcheck -s sh` and `-s bash` clean on the POSIX snippet, 0.095 ms/source,
`make uv-test` 58 passed / 9 skipped, and a negative control confirming a bad `include` path fails
loudly.

### Not in scope / follow-ups

- **Wiring the `.cuda` feature flag.** It is defined and emitted by `.chezmoi.yaml.tmpl` but read by
  no template; `[plugins.cuda]` gates on OS/distro instead. This PR corrects the four docs that
  claimed otherwise (`tutorials/03` was already right). Wiring it changes the plugin set and, since
  the default is `false`, would turn the module off for every new install — its own PR.
- **`chezmoi apply` is broken here** for unrelated reasons: a 2023-era
  `~/.config/chezmoi/chezmoi.yaml` predates `.version_manager`. `custom.zsh` needs no apply (sheldon
  sources it in place from the checkout, and `shell/` is `.chezmoiignore`d), so commit 1 is live
  immediately. The compat changes stay latent until that is fixed — harmless, since zsh never sources
  those files.
- **The sheldon templates are byte-identical** and nothing enforces it, and the XDG copy is never
  read because `SHELDON_CONFIG_DIR="$HOME/.sheldon"`. Untouched here.